### PR TITLE
feat: example configs with --config flag and E2E tests

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -77,6 +77,12 @@ tasks:
     cmds:
       - bash scripts/smoke-test.sh
 
+  e2e:configs:
+    desc: Run E2E tests with example configs against real OSS repos
+    deps: [build]
+    cmds:
+      - bash scripts/e2e-configs.sh
+
   test:integration:
     desc: Run integration tests using the installed gh velocity extension
     deps: [install]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,6 +85,7 @@ func NewRootCmd(version, buildTime string) *cobra.Command {
 	var (
 		formatFlag string
 		repoFlag   string
+		configFlag string
 		postFlag   bool
 	)
 
@@ -126,10 +127,18 @@ func NewRootCmd(version, buildTime string) *cobra.Command {
 			wd, _ := os.Getwd()
 			hasLocal := gitdata.IsLocalGitAvailable(wd) && localRepoMatches(wd, owner, repo)
 
-			// Load config: require file when local repo exists, fall back to defaults otherwise.
+			// Load config: use --config flag if set, otherwise default file.
+			configPath := config.DefaultConfigFile
+			if configFlag != "" {
+				configPath = configFlag
+			}
 			var cfg *config.Config
-			cfg, err = config.Load(config.DefaultConfigFile)
+			cfg, err = config.Load(configPath)
 			if err != nil {
+				if configFlag != "" {
+					// Explicit --config must exist and be valid.
+					return err
+				}
 				if hasLocal {
 					return err
 				}
@@ -164,6 +173,7 @@ func NewRootCmd(version, buildTime string) *cobra.Command {
 
 	root.PersistentFlags().StringVarP(&formatFlag, "format", "f", "pretty", "Output format: json, pretty, markdown")
 	root.PersistentFlags().StringVarP(&repoFlag, "repo", "R", "", "Repository in owner/name format")
+	root.PersistentFlags().StringVar(&configFlag, "config", "", "Path to config file (default: .gh-velocity.yml)")
 	root.PersistentFlags().BoolVar(&postFlag, "post", false, "Post output to GitHub")
 
 	root.AddCommand(NewVersionCmd(version, buildTime))

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,35 @@
+# Example Configurations
+
+Ready-to-use configs for popular open source projects. Each demonstrates different gh-velocity features.
+
+## Usage
+
+```bash
+gh velocity release <tag> --since <prev-tag> -R <owner/repo> --config docs/examples/<file>.yml -f json
+```
+
+## Feature Matrix
+
+| Config | Repo | bug_labels | feature_labels | active_labels | backlog_labels | commit_ref |
+|--------|------|:---:|:---:|:---:|:---:|:---:|
+| cli-cli.yml | cli/cli | x | x | x | x | x |
+| kubernetes-kubernetes.yml | kubernetes/kubernetes | x | x | x | x | |
+| hashicorp-terraform.yml | hashicorp/terraform | x | x | | x | |
+| astral-sh-uv.yml | astral-sh/uv | x | x | | | |
+| facebook-react.yml | facebook/react | x | x | x | x | |
+
+## E2E Testing
+
+These configs are validated by the E2E test suite:
+
+```bash
+task e2e:configs
+```
+
+This builds the binary and runs each config against its target repo, verifying that valid JSON output with metrics is returned.
+
+## Adding a New Example
+
+1. Create `<owner>-<repo>.yml` in this directory
+2. Add an entry to `scripts/e2e-configs.sh` with `config|repo|tag|since_tag`
+3. Run `task e2e:configs` to verify

--- a/docs/examples/astral-sh-uv.yml
+++ b/docs/examples/astral-sh-uv.yml
@@ -1,0 +1,14 @@
+# gh-velocity config for astral-sh/uv
+#
+# Fast Python package manager with rich label taxonomy.
+# Good example of: multiple bug/feature signals, performance as feature.
+#
+# Usage:
+#   gh velocity release 0.6.0 --since 0.5.0 -R astral-sh/uv --config docs/examples/astral-sh-uv.yml
+
+workflow: pr
+
+quality:
+  bug_labels: ["bug"]
+  feature_labels: ["enhancement", "performance"]
+  hotfix_window_hours: 24

--- a/docs/examples/cli-cli.yml
+++ b/docs/examples/cli-cli.yml
@@ -1,0 +1,21 @@
+# gh-velocity config for cli/cli (GitHub CLI)
+#
+# Label-based workflow — no Projects v2, uses labels for status tracking.
+# Good example of: active_labels, backlog_labels, commit_ref patterns.
+#
+# Usage:
+#   gh velocity release v2.65.0 --since v2.64.0 -R cli/cli --config docs/examples/cli-cli.yml
+
+workflow: pr
+
+statuses:
+  backlog_labels: ["needs-design", "needs-investigation"]
+  active_labels: ["core"]
+
+quality:
+  bug_labels: ["bug"]
+  feature_labels: ["enhancement"]
+  hotfix_window_hours: 48
+
+commit_ref:
+  patterns: ["closes"]

--- a/docs/examples/facebook-react.yml
+++ b/docs/examples/facebook-react.yml
@@ -1,0 +1,18 @@
+# gh-velocity config for facebook/react
+#
+# Uses "Type:" prefixed labels for classification.
+# Good example of: non-standard label naming conventions.
+#
+# Usage:
+#   gh velocity release v19.1.0 --since v19.0.0 -R facebook/react --config docs/examples/facebook-react.yml
+
+workflow: pr
+
+statuses:
+  backlog_labels: ["Status: Unconfirmed"]
+  active_labels: ["Status: New"]
+
+quality:
+  bug_labels: ["Type: Bug", "Type: Regression"]
+  feature_labels: ["Type: Enhancement", "Type: Feature Request"]
+  hotfix_window_hours: 24

--- a/docs/examples/hashicorp-terraform.yml
+++ b/docs/examples/hashicorp-terraform.yml
@@ -1,0 +1,17 @@
+# gh-velocity config for hashicorp/terraform
+#
+# Infrastructure tool with standard label conventions.
+# Good example of: simple label-only classification, no active_labels.
+#
+# Usage:
+#   gh velocity release v1.11.0 --since v1.10.0 -R hashicorp/terraform --config docs/examples/hashicorp-terraform.yml
+
+workflow: pr
+
+statuses:
+  backlog_labels: ["pending-decision"]
+
+quality:
+  bug_labels: ["bug", "crash"]
+  feature_labels: ["enhancement"]
+  hotfix_window_hours: 48

--- a/docs/examples/kubernetes-kubernetes.yml
+++ b/docs/examples/kubernetes-kubernetes.yml
@@ -1,0 +1,18 @@
+# gh-velocity config for kubernetes/kubernetes
+#
+# Massive monorepo with SIG-based labels and kind/* classification.
+# Good example of: granular bug/feature labels using Kubernetes conventions.
+#
+# Usage:
+#   gh velocity release v1.32.0 --since v1.31.0 -R kubernetes/kubernetes --config docs/examples/kubernetes-kubernetes.yml
+
+workflow: pr
+
+statuses:
+  backlog_labels: ["priority/backlog", "lifecycle/frozen"]
+  active_labels: ["priority/critical-urgent", "priority/important-soon"]
+
+quality:
+  bug_labels: ["kind/bug"]
+  feature_labels: ["kind/feature", "kind/api-change"]
+  hotfix_window_hours: 24

--- a/scripts/e2e-configs.sh
+++ b/scripts/e2e-configs.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# E2E tests — run each example config against its target repo and validate JSON output.
+# Requires: gh auth (valid GitHub token), built ./gh-velocity binary.
+set -euo pipefail
+
+BINARY="./gh-velocity"
+PASS=0
+FAIL=0
+ERRORS=""
+
+pass() { PASS=$((PASS + 1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL + 1)); ERRORS+="  ✗ $1\n"; echo "  ✗ $1" >&2; }
+
+# Check binary exists
+if [[ ! -x "$BINARY" ]]; then
+  echo "ERROR: $BINARY not found. Run 'task build' first." >&2
+  exit 1
+fi
+
+echo "E2E config tests"
+echo "================"
+
+# Each entry: config_file repo tag since_tag
+configs=(
+  "docs/examples/cli-cli.yml|cli/cli|v2.87.3|v2.87.2"
+  "docs/examples/kubernetes-kubernetes.yml|kubernetes/kubernetes|v1.35.2|v1.34.5"
+  "docs/examples/hashicorp-terraform.yml|hashicorp/terraform|v1.14.6|v1.14.5"
+  "docs/examples/astral-sh-uv.yml|astral-sh/uv|0.10.9|0.10.8"
+  "docs/examples/facebook-react.yml|facebook/react|v19.2.4|v19.1.5"
+)
+
+for entry in "${configs[@]}"; do
+  IFS='|' read -r config repo tag since <<< "$entry"
+  name=$(basename "$config" .yml)
+
+  echo ""
+  echo "$name ($repo $tag)"
+
+  # Run release command with the example config
+  out=$($BINARY release "$tag" --since "$since" -R "$repo" --config "$config" -f json 2>/dev/null) || {
+    fail "$name: command failed"
+    continue
+  }
+
+  # Validate JSON is parseable
+  if ! echo "$out" | jq . >/dev/null 2>&1; then
+    fail "$name: invalid JSON output"
+    continue
+  fi
+
+  # Validate tag field matches
+  got_tag=$(echo "$out" | jq -r '.tag' 2>/dev/null)
+  if [[ "$got_tag" == "$tag" ]]; then
+    pass "$name: tag matches"
+  else
+    fail "$name: expected tag $tag, got $got_tag"
+  fi
+
+  # Validate we got some data (composition.total_issues or issues array)
+  total=$(echo "$out" | jq -r '.composition.total_issues // 0' 2>/dev/null)
+  issues_len=$(echo "$out" | jq -r '.issues | length // 0' 2>/dev/null)
+  if [[ "$total" -gt 0 ]] || [[ "$issues_len" -gt 0 ]]; then
+    pass "$name: has issue data (total=$total, issues=$issues_len)"
+  else
+    # Some releases may legitimately have 0 issues; just warn
+    echo "  ⚠ $name: no issues found (may be expected for this release pair)"
+  fi
+
+  # Validate composition metrics exist
+  if echo "$out" | jq -e '.composition.bug_count >= 0' >/dev/null 2>&1; then
+    pass "$name: has composition metrics"
+  else
+    fail "$name: missing composition metrics"
+  fi
+
+  # Validate aggregates exist
+  if echo "$out" | jq -e '.aggregates.lead_time' >/dev/null 2>&1; then
+    pass "$name: has aggregates"
+  else
+    fail "$name: missing aggregates"
+  fi
+done
+
+# ── summary ────────────────────────────────────────────────────────
+echo ""
+echo "================"
+echo "Passed: $PASS  Failed: $FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  echo "" >&2
+  echo "Failures:" >&2
+  echo -e "$ERRORS" >&2
+  exit 1
+fi
+
+echo "All E2E config tests passed."


### PR DESCRIPTION
## Summary
- Add global `--config` flag to override `.gh-velocity.yml` path
- Create 5 example configs for popular OSS projects covering all config features
- Add E2E test suite (`task e2e:configs`) that validates each config against real repos

## Example Configs

| Config | Repo | Features Covered |
|--------|------|-----------------|
| cli-cli.yml | cli/cli | active_labels, backlog_labels, commit_ref |
| kubernetes-kubernetes.yml | kubernetes/kubernetes | kind/* labels, priority-based backlog |
| hashicorp-terraform.yml | hashicorp/terraform | Simple label classification |
| astral-sh-uv.yml | astral-sh/uv | Minimal config, performance as feature |
| facebook-react.yml | facebook/react | Type: prefixed labels, Status: labels |

## Test plan
- [x] `go test ./...` — all unit tests pass
- [x] `task e2e:configs` — all 19 assertions pass across 5 repos
- [x] `--config` flag errors when file doesn't exist
- [x] `--config` flag loads alternate config correctly

Closes #6

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>