### PR TITLE
feat: config preflight and launch polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A GitHub CLI extension that measures how fast your team ships.
 
-`gh velocity` computes lead time, cycle time, release lag, and quality metrics from your existing GitHub data — issues, pull requests, releases, and commits. No external services, no tracking pixels, no configuration databases. Just your repo.
+`gh velocity` computes lead time, cycle time, release quality, and work-in-progress metrics from your existing GitHub data — issues, pull requests, releases, and commits. No external services, no tracking pixels, no configuration databases. Just your repo.
 
 ## Install
 
@@ -14,53 +14,77 @@ Requires [GitHub CLI](https://cli.github.com/) 2.0+.
 
 ## Quick start
 
-Most commands work against any repo via `-R`:
+Try it now against any public repo — no config needed:
 
 ```bash
+# How long do issues take to close? (last 30 days)
+gh velocity flow lead-time --since 30d -R cli/cli
+
 # How did the last release go?
-gh velocity release v2.67.0 -R cli/cli
+gh velocity quality release v2.67.0 -R cli/cli --since v2.66.0
 
-# What's in a release? Which strategy found each issue?
-gh velocity scope v2.67.0 -R cli/cli
-
-# How long did a specific issue take?
-gh velocity lead-time 42 -R cli/cli
+# Everything at a glance (composite dashboard)
+gh velocity report --since 30d -R cli/cli
 ```
 
-Cycle time works remotely too — it uses PR creation dates and assignment events from the API:
-
-```bash
-gh velocity cycle-time 42 -R cli/cli
-```
-
-From inside any local repo, you can omit `-R`:
+From inside your own repo, omit `-R`:
 
 ```bash
 cd your-repo
-gh velocity release v1.2.0
+gh velocity flow lead-time 42
+gh velocity report
 ```
 
-## Output formats
+### Set up your repo (optional but recommended)
+
+```bash
+# 1. Analyze your repo and generate a tailored config
+gh velocity config preflight -R owner/repo --project 3
+
+# 2. Save it
+gh velocity config preflight --write --project 3
+
+# 3. Validate
+gh velocity config validate
+```
+
+Not sure which project number to use? Run `gh velocity config discover -R owner/repo` to list them.
+
+## Commands
+
+```
+gh velocity
+├── flow                              # How fast are we?
+│   ├── lead-time [<issue> | --since] # Created → closed
+│   └── cycle-time [<issue> | --pr N | --since]
+│
+├── quality                           # How good is our output?
+│   └── release <tag> [--since] [--scope]
+│
+├── status                            # What's happening now?
+│   └── wip                           # Work in progress
+│
+├── report [--since] [--until]        # Composite dashboard
+│
+├── config
+│   ├── preflight [-R repo] [--project N]  # Analyze repo, suggest config
+│   ├── create                             # Generate starter config
+│   ├── discover [-R repo]                 # Find project board IDs
+│   ├── show                               # Display resolved config
+│   └── validate                           # Check for errors
+│
+└── version
+```
+
+### Output formats
 
 Every command supports three formats:
 
 ```bash
-gh velocity release v1.2.0                    # human-readable table
-gh velocity release v1.2.0 -f json            # structured JSON
-gh velocity release v1.2.0 -f markdown        # paste into an issue or PR
+gh velocity report                    # human-readable (default)
+gh velocity report -f json            # structured JSON (for CI/scripts)
+gh velocity report -f markdown        # paste into an issue or PR
 ```
-
-## Commands
-
-| Command | What it measures | Needs local clone? |
-| --- | --- | --- |
-| `release <tag>` | Full release report: per-issue metrics, composition, aggregates, outliers | No (but improves accuracy) |
-| `scope <tag>` | What a release contains, broken down by discovery strategy | No |
-| `lead-time <issue>` | Time from issue creation to close | No |
-| `cycle-time <issue>` | Time from work started to close | No (local clone adds commit data) |
-| `config show` | Display resolved configuration | No |
-| `config create` | Generate a default `.gh-velocity.yml` | No |
-| `config validate` | Check your `.gh-velocity.yml` for errors | No |
 
 ### Common flags
 
@@ -68,46 +92,108 @@ gh velocity release v1.2.0 -f markdown        # paste into an issue or PR
 | --- | --- | --- |
 | `--format` | `-f` | Output: `pretty` (default), `json`, `markdown` |
 | `--repo` | `-R` | Target repo as `owner/name` |
-| `--since` | | Previous tag override (on `release` and `scope`) |
+| `--since` | | Start of date window or previous tag |
+| `--until` | | End of date window (default: now) |
 
 ## What gets measured
 
-The `release` command computes these metrics for every issue in a release:
+### Flow metrics
 
 - **Lead time** — issue created to issue closed
-- **Cycle time** — work started (board status change, label, PR created, assigned, or first commit) to issue closed
-- **Release lag** — issue closed to release published
+- **Cycle time** — work started to issue closed (configurable strategy: issue, PR, or project board)
 
-Aggregates include mean, median, standard deviation, P90, P95, and IQR-based outlier detection. Individual issues are flagged when they exceed the outlier threshold.
+### Quality metrics (per release)
+
+- **Per-issue lead time, cycle time, and release lag** (closed → released)
+- **Composition** — categorize issues by label (bug, feature, or custom categories)
+- **Hotfix detection** — flag issues closed very close to release
+- **Aggregates** — mean, median, P90, P95, IQR-based outlier detection
+
+### Status
+
+- **WIP** — items currently in progress (from Projects v2 board or labels)
+
+### Report (composite dashboard)
+
+- Lead time, cycle time, throughput, WIP, and quality in a single view
+- Each section computes independently — a failure in one doesn't block others
 
 ## How issues are discovered
 
 Three strategies run in parallel to find which issues belong to a release:
 
-1. **pr-link** — finds merged PRs in the release window, then follows GitHub's "closing references" to linked issues
-2. **commit-ref** — scans commit messages for closing keywords (`fixes #N`, `closes #N`, `resolves #N`)
-3. **changelog** — parses the release body for `#N` references
+1. **pr-link** — merged PRs in the release window → GitHub closing references → linked issues
+2. **commit-ref** — commit messages scanned for `fixes #N`, `closes #N`, `resolves #N`
+3. **changelog** — release body parsed for `#N` references
 
-Results are merged with priority (pr-link > commit-ref > changelog). Use `scope` to see what each strategy finds.
+Results merge with priority (pr-link > commit-ref > changelog). Use `--scope` to see what each strategy finds.
 
 ## Configuration
 
-Create `.gh-velocity.yml` in your repo root. All fields are optional:
+All fields are optional. `gh velocity` works without a config file using sensible defaults.
+
+### Generate a tailored config
+
+```bash
+# Preflight analyzes your repo's labels, project boards, and recent activity
+gh velocity config preflight -R owner/repo --project 3
+
+# Save directly
+gh velocity config preflight --write --project 3
+```
+
+### Manual config
+
+Create `.gh-velocity.yml` in your repo root:
 
 ```yaml
 # Issue classification
 quality:
   bug_labels: ["bug", "defect"]
-  feature_labels: ["enhancement", "feature"]
-  hotfix_window_hours: 48
+  feature_labels: ["enhancement"]
+  hotfix_window_hours: 72
 
 # Commit message patterns
 commit_ref:
-  patterns: ["closes"]          # default: closing keywords only
-  # patterns: ["closes", "refs"]  # also match bare #N references
+  patterns: ["closes"]    # "refs" also matches bare #N references
+
+# Cycle time strategy: "issue" (default), "pr", or "project-board"
+cycle_time:
+  strategy: issue
+
+# Projects v2 board (enables WIP and project-board cycle time)
+# Find these IDs with: gh velocity config discover
+# project:
+#   id: "PVT_kwDOAbc123"
+#   status_field_id: "PVTSSF_kwDOAbc123"
+
+# Label-based status (alternative to project board)
+# statuses:
+#   active_labels: ["in-progress", "wip"]
+#   backlog_labels: ["backlog", "icebox"]
 ```
 
-See [docs/guide.md](docs/guide.md) for the full configuration reference and detailed examples.
+See [docs/guide.md](docs/guide.md) for the full configuration reference, metric definitions, and examples for popular OSS repos.
+
+## Example output
+
+```
+$ gh velocity report --since 30d -R cli/cli
+
+Report: cli/cli (2026-02-08 – 2026-03-10 UTC)
+
+  Lead Time:   median 4.2d, mean 12.1d, P90 30.5d (n=47, 3 outliers)
+  Cycle Time:  median 1.1d, mean 3.8d, P90 9.2d (n=47)
+  Throughput:  47 issues closed, 52 PRs merged
+```
+
+```
+$ gh velocity flow lead-time 9876 -R cli/cli
+
+Issue #9876  Fix table alignment in `gh pr list`
+  Created:   2026-02-15T14:30:00Z UTC
+  Lead Time: 3d 4h 12m
+```
 
 ## License
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -16,13 +16,20 @@ import (
 func NewConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
-		Short: "Inspect and validate configuration",
+		Short: "Inspect, validate, and generate configuration",
+		Long: `Configuration commands for .gh-velocity.yml.
+
+Getting started:
+  1. gh velocity config preflight -R owner/repo  # analyze repo, suggest config
+  2. gh velocity config create                    # generate starter config
+  3. gh velocity config validate                  # check for errors`,
 	}
 
 	cmd.AddCommand(newConfigShowCmd())
 	cmd.AddCommand(newConfigValidateCmd())
 	cmd.AddCommand(newConfigCreateCmd())
 	cmd.AddCommand(newConfigDiscoverCmd())
+	cmd.AddCommand(newConfigPreflightCmd())
 
 	return cmd
 }
@@ -31,6 +38,8 @@ func newConfigShowCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "show",
 		Short: "Display resolved configuration with defaults applied",
+		Example: `  gh velocity config show
+  gh velocity config show -f json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load(config.DefaultConfigFile)
 			if err != nil {
@@ -77,8 +86,9 @@ func newConfigShowCmd() *cobra.Command {
 
 func newConfigValidateCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "validate",
-		Short: "Validate configuration and report errors",
+		Use:     "validate",
+		Short:   "Validate configuration and report errors",
+		Example: `  gh velocity config validate`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_, err := config.Load(config.DefaultConfigFile)
 			if err != nil {
@@ -134,7 +144,12 @@ func newConfigCreateCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "create",
 		Short: "Create a default .gh-velocity.yml in the current directory",
-		Args:  cobra.NoArgs,
+		Long: `Generate a starter .gh-velocity.yml with sensible defaults.
+
+For a smarter config tailored to your repo, use 'config preflight' first:
+  gh velocity config preflight -R owner/repo`,
+		Example: `  gh velocity config create`,
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := config.DefaultConfigFile
 			if _, err := os.Stat(path); err == nil {
@@ -161,6 +176,11 @@ repository, then lists their fields and status options.
 
 Use this to find the project.id and project.status_field_id values
 needed for .gh-velocity.yml configuration.`,
+		Example: `  # Discover projects for a remote repo
+  gh velocity config discover -R cli/cli
+
+  # JSON output for scripting
+  gh velocity config discover -R owner/repo -f json`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Config subcommands skip PersistentPreRunE, so resolve repo here.

--- a/cmd/cycletime.go
+++ b/cmd/cycletime.go
@@ -39,6 +39,17 @@ Bulk mode:    gh velocity cycle-time --since 30d [--until 2026-03-01]
 
 The --pr flag overrides the configured strategy for a single run.
 When a signal is not available for an item, cycle time is N/A.`,
+		Example: `  # Single issue (uses configured strategy)
+  gh velocity flow cycle-time 42
+
+  # Single PR (always uses PR created → merged)
+  gh velocity flow cycle-time --pr 99
+
+  # All issues closed in the last 30 days
+  gh velocity flow cycle-time --since 30d
+
+  # Remote repo, markdown output
+  gh velocity flow cycle-time --since 14d -R cli/cli -f markdown`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Conflict: --since with positional or --pr

--- a/cmd/leadtime.go
+++ b/cmd/leadtime.go
@@ -26,6 +26,15 @@ Bulk mode:    gh velocity lead-time --since 30d [--until 2026-03-01]
 
 In bulk mode, returns per-item rows plus aggregate statistics
 for all issues closed in the given date window.`,
+		Example: `  # Single issue
+  gh velocity flow lead-time 42
+  gh velocity flow lead-time 42 -R cli/cli
+
+  # All issues closed in the last 30 days
+  gh velocity flow lead-time --since 30d
+
+  # Custom window, JSON output
+  gh velocity flow lead-time --since 2026-01-01 --until 2026-02-01 -f json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 && sinceFlag != "" {

--- a/cmd/preflight.go
+++ b/cmd/preflight.go
@@ -1,0 +1,393 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/bitsbyme/gh-velocity/internal/format"
+	gh "github.com/bitsbyme/gh-velocity/internal/github"
+	"github.com/bitsbyme/gh-velocity/internal/model"
+	"github.com/spf13/cobra"
+)
+
+func newConfigPreflightCmd() *cobra.Command {
+	var (
+		writeFlag   bool
+		projectFlag int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "preflight",
+		Short: "Analyze a repo and recommend a .gh-velocity.yml configuration",
+		Long: `Preflight queries your repository to build a smart starting configuration.
+
+It inspects:
+  - Labels (to detect bug, feature, and status labels)
+  - A specific Projects v2 board (to find board IDs and status fields)
+  - Recent merged PRs (to gauge activity and linking patterns)
+  - Recent closed issues (to check label usage)
+
+Use --project to specify which project board number to analyze.
+Find project numbers with: gh velocity config discover -R owner/repo
+
+The output is a recommended .gh-velocity.yml with comments explaining
+each choice. Use --write to save it directly.`,
+		Example: `  # Analyze repo and a specific project board
+  gh velocity config preflight -R owner/repo --project 3
+
+  # Without a project board (label-based analysis only)
+  gh velocity config preflight -R cli/cli
+
+  # Write config directly to .gh-velocity.yml
+  gh velocity config preflight --write --project 3
+
+  # JSON output for tooling
+  gh velocity config preflight -R owner/repo -f json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Config subcommands skip PersistentPreRunE, so resolve repo here.
+			repoFlag, _ := cmd.Root().PersistentFlags().GetString("repo")
+			owner, repo, err := resolveRepo(repoFlag)
+			if err != nil {
+				return err
+			}
+
+			client, err := gh.NewClient(owner, repo)
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			w := cmd.OutOrStdout()
+			formatFlag, _ := cmd.Root().PersistentFlags().GetString("format")
+
+			fmt.Fprintf(os.Stderr, "Analyzing %s/%s...\n", owner, repo)
+
+			result, err := runPreflight(ctx, client, owner, repo, projectFlag)
+			if err != nil {
+				return err
+			}
+
+			if formatFlag == "json" {
+				enc := json.NewEncoder(w)
+				enc.SetIndent("", "  ")
+				return enc.Encode(result)
+			}
+
+			configYAML := renderPreflightConfig(result)
+
+			if writeFlag {
+				path := ".gh-velocity.yml"
+				if _, statErr := os.Stat(path); statErr == nil {
+					return &model.AppError{
+						Code:    model.ErrConfigInvalid,
+						Message: fmt.Sprintf("%s already exists; remove it first or edit it directly", path),
+					}
+				}
+				if writeErr := os.WriteFile(path, []byte(configYAML), 0644); writeErr != nil {
+					return fmt.Errorf("write %s: %w", path, writeErr)
+				}
+				fmt.Fprintf(os.Stderr, "Wrote %s\n", path)
+				return nil
+			}
+
+			fmt.Fprint(w, configYAML)
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "To save this config:  gh velocity config preflight --write")
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&writeFlag, "write", false, "Write the recommended config to .gh-velocity.yml")
+	cmd.Flags().IntVar(&projectFlag, "project", 0, "Project board number to analyze (find with 'config discover')")
+	return cmd
+}
+
+// PreflightResult holds the analysis of a repository for config generation.
+type PreflightResult struct {
+	Repo          string       `json:"repo"`
+	BugLabels     []string     `json:"bug_labels"`
+	FeatureLabels []string     `json:"feature_labels"`
+	ActiveLabels  []string     `json:"active_labels"`
+	BacklogLabels []string     `json:"backlog_labels"`
+	ProjectID     string       `json:"project_id,omitempty"`
+	StatusFieldID string       `json:"status_field_id,omitempty"`
+	StatusOptions []string     `json:"status_options,omitempty"`
+	Strategy      string       `json:"strategy"`
+	HasProject    bool         `json:"has_project"`
+	RecentIssues  int          `json:"recent_issues_closed"`
+	RecentPRs     int          `json:"recent_prs_merged"`
+	AllLabels     []labelCount `json:"labels"`
+	Hints         []string     `json:"hints"`
+}
+
+type labelCount struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+func runPreflight(ctx context.Context, client *gh.Client, owner, repo string, projectNumber int) (*PreflightResult, error) {
+	result := &PreflightResult{
+		Repo:     owner + "/" + repo,
+		Strategy: "issue", // default
+	}
+
+	// 1. Fetch labels from repo
+	labels, err := client.ListLabels(ctx)
+	if err != nil {
+		result.Hints = append(result.Hints, fmt.Sprintf("Could not fetch labels: %v", err))
+	} else {
+		classifyLabels(result, labels)
+	}
+
+	// 2. Discover project board (if --project specified)
+	if projectNumber > 0 {
+		project, projErr := client.DiscoverProjectByNumber(ctx, projectNumber)
+		if projErr != nil {
+			result.Hints = append(result.Hints, fmt.Sprintf("Could not fetch project #%d: %v", projectNumber, projErr))
+		} else {
+			for _, f := range project.Fields {
+				if strings.EqualFold(f.Name, "Status") && len(f.Options) > 0 {
+					result.HasProject = true
+					result.ProjectID = project.ID
+					result.StatusFieldID = f.ID
+					for _, o := range f.Options {
+						result.StatusOptions = append(result.StatusOptions, o.Name)
+					}
+					result.Strategy = "project-board"
+					result.Hints = append(result.Hints, fmt.Sprintf("Using project board: %s (#%d)", project.Title, project.Number))
+					break
+				}
+			}
+			if !result.HasProject {
+				result.Hints = append(result.Hints, fmt.Sprintf("Project #%d has no Status field with options", projectNumber))
+			}
+		}
+	}
+
+	// 3. Check recent activity (last 30 days)
+	now := time.Now().UTC()
+	since := now.Add(-30 * 24 * time.Hour)
+
+	issues, err := client.SearchClosedIssues(ctx, since, now)
+	if err != nil {
+		result.Hints = append(result.Hints, fmt.Sprintf("Could not search recent issues: %v", err))
+	} else {
+		result.RecentIssues = len(issues)
+		countLabelUsage(result, issues)
+	}
+
+	prs, err := client.SearchMergedPRs(ctx, since, now)
+	if err != nil {
+		result.Hints = append(result.Hints, fmt.Sprintf("Could not search recent PRs: %v", err))
+	} else {
+		result.RecentPRs = len(prs)
+	}
+
+	// 4. Infer strategy
+	if !result.HasProject && result.RecentPRs > result.RecentIssues {
+		result.Strategy = "pr"
+		result.Hints = append(result.Hints, "More PRs than issues in the last 30 days — PR-centric workflow detected")
+	} else if result.HasProject {
+		result.Hints = append(result.Hints, "Project board detected — using project-board strategy for cycle time")
+	} else {
+		result.Hints = append(result.Hints, "Using default issue strategy (created → closed)")
+	}
+
+	// 5. Suggest active/backlog labels if no project board
+	if !result.HasProject && len(result.ActiveLabels) > 0 {
+		result.Hints = append(result.Hints, fmt.Sprintf("Found status labels: %v — can be used for WIP tracking", result.ActiveLabels))
+	}
+
+	if result.RecentIssues == 0 && result.RecentPRs == 0 {
+		result.Hints = append(result.Hints, "No recent activity found in the last 30 days — metrics may be empty initially")
+	}
+
+	return result, nil
+}
+
+// classifyLabels sorts repo labels into bug, feature, active, and backlog buckets.
+func classifyLabels(result *PreflightResult, labels []string) {
+	bugPatterns := []string{"bug", "defect", "regression", "error", "crash"}
+	featurePatterns := []string{"enhancement", "feature", "feat", "improvement"}
+	activePatterns := []string{"in-progress", "in progress", "wip", "working", "active", "doing"}
+	backlogPatterns := []string{"backlog", "icebox", "deferred", "later", "someday", "wishlist"}
+
+	for _, label := range labels {
+		lower := strings.ToLower(label)
+		if matchesAny(lower, bugPatterns) {
+			result.BugLabels = append(result.BugLabels, label)
+		}
+		if matchesAny(lower, featurePatterns) {
+			result.FeatureLabels = append(result.FeatureLabels, label)
+		}
+		if matchesAny(lower, activePatterns) {
+			result.ActiveLabels = append(result.ActiveLabels, label)
+		}
+		if matchesAny(lower, backlogPatterns) {
+			result.BacklogLabels = append(result.BacklogLabels, label)
+		}
+	}
+}
+
+func matchesAny(label string, patterns []string) bool {
+	for _, p := range patterns {
+		if strings.Contains(label, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// countLabelUsage counts how often each label appears on recent closed issues.
+func countLabelUsage(result *PreflightResult, issues []model.Issue) {
+	counts := make(map[string]int)
+	for _, issue := range issues {
+		for _, l := range issue.Labels {
+			counts[l]++
+		}
+	}
+
+	var sorted []labelCount
+	for name, count := range counts {
+		sorted = append(sorted, labelCount{Name: name, Count: count})
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Count > sorted[j].Count })
+
+	// Keep top 20
+	if len(sorted) > 20 {
+		sorted = sorted[:20]
+	}
+	result.AllLabels = sorted
+}
+
+// renderPreflightConfig generates a commented .gh-velocity.yml from analysis results.
+func renderPreflightConfig(r *PreflightResult) string {
+	var b strings.Builder
+
+	b.WriteString("# gh-velocity configuration\n")
+	b.WriteString(fmt.Sprintf("# Generated by: gh velocity config preflight -R %s\n", r.Repo))
+	b.WriteString(fmt.Sprintf("# Date: %s\n", time.Now().UTC().Format(time.DateOnly)))
+	b.WriteString("#\n")
+	for _, hint := range r.Hints {
+		b.WriteString(fmt.Sprintf("# %s\n", hint))
+	}
+	b.WriteString("\n")
+
+	// Quality labels
+	b.WriteString("# Issue classification labels\n")
+	b.WriteString("quality:\n")
+	if len(r.BugLabels) > 0 {
+		b.WriteString(fmt.Sprintf("  bug_labels: %s\n", format.FormatStringSlice(r.BugLabels)))
+	} else {
+		b.WriteString("  bug_labels: [\"bug\"]\n")
+	}
+	if len(r.FeatureLabels) > 0 {
+		b.WriteString(fmt.Sprintf("  feature_labels: %s\n", format.FormatStringSlice(r.FeatureLabels)))
+	} else {
+		b.WriteString("  feature_labels: [\"enhancement\"]\n")
+	}
+	b.WriteString("  hotfix_window_hours: 72\n")
+	b.WriteString("\n")
+
+	// Commit patterns
+	b.WriteString("# Commit message scanning\n")
+	b.WriteString("commit_ref:\n")
+	b.WriteString("  patterns: [\"closes\"]\n")
+	b.WriteString("\n")
+
+	// Cycle time strategy
+	b.WriteString(fmt.Sprintf("# Cycle time strategy: %s\n", r.Strategy))
+	b.WriteString("cycle_time:\n")
+	b.WriteString(fmt.Sprintf("  strategy: %s\n", r.Strategy))
+	b.WriteString("\n")
+
+	// Project board config (if detected)
+	if r.HasProject {
+		b.WriteString("# Projects v2 board (auto-detected)\n")
+		b.WriteString("project:\n")
+		b.WriteString(fmt.Sprintf("  id: %q\n", r.ProjectID))
+		b.WriteString(fmt.Sprintf("  status_field_id: %q\n", r.StatusFieldID))
+		b.WriteString("\n")
+
+		// Try to map status options to statuses
+		b.WriteString("# Board column mapping\n")
+		b.WriteString("statuses:\n")
+		writeStatusMapping(&b, r.StatusOptions)
+		b.WriteString("\n")
+	} else if len(r.ActiveLabels) > 0 || len(r.BacklogLabels) > 0 {
+		b.WriteString("# Label-based status tracking (no project board detected)\n")
+		b.WriteString("statuses:\n")
+		if len(r.ActiveLabels) > 0 {
+			b.WriteString(fmt.Sprintf("  active_labels: %s\n", format.FormatStringSlice(r.ActiveLabels)))
+		}
+		if len(r.BacklogLabels) > 0 {
+			b.WriteString(fmt.Sprintf("  backlog_labels: %s\n", format.FormatStringSlice(r.BacklogLabels)))
+		}
+		b.WriteString("\n")
+	}
+
+	// Activity summary as comments
+	b.WriteString(fmt.Sprintf("# Recent activity (last 30 days): %d issues closed, %d PRs merged\n", r.RecentIssues, r.RecentPRs))
+
+	if len(r.AllLabels) > 0 {
+		b.WriteString("# Most-used labels on recent closed issues:\n")
+		for _, lc := range r.AllLabels {
+			if lc.Count > 1 {
+				b.WriteString(fmt.Sprintf("#   %s (%d)\n", lc.Name, lc.Count))
+			}
+		}
+	}
+
+	return b.String()
+}
+
+// writeStatusMapping tries to map project board status options to config fields.
+func writeStatusMapping(b *strings.Builder, options []string) {
+	backlog := findStatus(options, "backlog", "to do", "todo", "triage", "new")
+	ready := findStatus(options, "ready", "planned", "up next")
+	inProgress := findStatus(options, "in progress", "doing", "active", "working")
+	inReview := findStatus(options, "in review", "review", "pending review")
+	done := findStatus(options, "done", "closed", "complete", "completed", "shipped")
+
+	if backlog != "" {
+		b.WriteString(fmt.Sprintf("  backlog: %q\n", backlog))
+	}
+	if ready != "" {
+		b.WriteString(fmt.Sprintf("  ready: %q\n", ready))
+	}
+	if inProgress != "" {
+		b.WriteString(fmt.Sprintf("  in_progress: %q\n", inProgress))
+	}
+	if inReview != "" {
+		b.WriteString(fmt.Sprintf("  in_review: %q\n", inReview))
+	}
+	if done != "" {
+		b.WriteString(fmt.Sprintf("  done: %q\n", done))
+	}
+
+	// Show unmapped options as comments
+	mapped := map[string]bool{backlog: true, ready: true, inProgress: true, inReview: true, done: true}
+	for _, o := range options {
+		if !mapped[o] && o != "" {
+			b.WriteString(fmt.Sprintf("  # unmapped: %q\n", o))
+		}
+	}
+}
+
+func findStatus(options []string, patterns ...string) string {
+	for _, o := range options {
+		lower := strings.ToLower(o)
+		for _, p := range patterns {
+			if strings.Contains(lower, p) {
+				return o
+			}
+		}
+	}
+	return ""
+}

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -28,6 +28,17 @@ func NewReleaseCmd() *cobra.Command {
 
 Use --scope to show the scope diagnostic view: which issues and PRs each
 linking strategy discovered for the release.`,
+		Example: `  # Release metrics with auto-detected previous tag
+  gh velocity quality release v2.65.0
+
+  # Explicit previous tag
+  gh velocity quality release v2.65.0 --since v2.64.0
+
+  # Scope diagnostic: what did each strategy find?
+  gh velocity quality release v2.65.0 --scope
+
+  # Remote repo, JSON output
+  gh velocity quality release v2.65.0 -R cli/cli -f json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			tag := args[0]

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -29,6 +29,14 @@ Each section computes independently; a failure in one section does not
 block others. Sections that require specific config (WIP needs project.id
 or active_labels; quality needs releases) are gracefully omitted when
 unavailable.`,
+		Example: `  # Default: last 30 days
+  gh velocity report
+
+  # Custom window
+  gh velocity report --since 14d --until 2026-03-01
+
+  # Remote repo, JSON for CI dashboards
+  gh velocity report --since 30d -R cli/cli -f json`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -143,10 +143,16 @@ func NewRootCmd(version, buildTime string) *cobra.Command {
 			if err != nil {
 				if configFlag != "" {
 					// Explicit --config must exist and be valid.
-					return err
+					return &model.AppError{
+						Code:    model.ErrConfigInvalid,
+						Message: fmt.Sprintf("%v\n\n  To generate a starter config:  gh velocity config create\n  To auto-detect your setup:    gh velocity config preflight", err),
+					}
 				}
 				if hasLocal {
-					return err
+					return &model.AppError{
+						Code:    model.ErrConfigInvalid,
+						Message: fmt.Sprintf("%v\n\n  To generate a starter config:  gh velocity config create\n  To auto-detect your setup:    gh velocity config preflight", err),
+					}
 				}
 				// Config file not found is fine when running without
 				// a local repo — use defaults.
@@ -180,7 +186,8 @@ func NewRootCmd(version, buildTime string) *cobra.Command {
 	root.PersistentFlags().StringVarP(&formatFlag, "format", "f", "pretty", "Output format: json, pretty, markdown")
 	root.PersistentFlags().StringVarP(&repoFlag, "repo", "R", "", "Repository in owner/name format")
 	root.PersistentFlags().StringVar(&configFlag, "config", "", "Path to config file (default: .gh-velocity.yml)")
-	root.PersistentFlags().BoolVar(&postFlag, "post", false, "Post output to GitHub")
+	root.PersistentFlags().BoolVar(&postFlag, "post", false, "Post output to GitHub (coming soon)")
+	root.PersistentFlags().MarkHidden("post")
 
 	root.AddCommand(NewVersionCmd(version, buildTime))
 	root.AddCommand(NewConfigCmd())

--- a/cmd/wip.go
+++ b/cmd/wip.go
@@ -20,6 +20,14 @@ Primary source: Projects v2 board status (requires project.id in config).
 Fallback: open issues with active_labels (requires statuses.active_labels in config).
 
 Use -R owner/repo to filter board items to a specific repo.`,
+		Example: `  # Show WIP from configured project board
+  gh velocity status wip
+
+  # Filter to a specific repo on the board
+  gh velocity status wip -R owner/repo
+
+  # JSON output for CI/automation
+  gh velocity status wip -f json`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -111,7 +119,7 @@ Use -R owner/repo to filter board items to a specific repo.`,
 			} else {
 				return &model.AppError{
 					Code:    model.ErrConfigInvalid,
-					Message: "wip requires either project.id or statuses.active_labels in .gh-velocity.yml",
+					Message: "wip requires either project.id or statuses.active_labels in .gh-velocity.yml\n\n  To auto-detect your setup:  gh velocity config preflight -R owner/repo\n  To find project board IDs:  gh velocity config discover -R owner/repo",
 				}
 			}
 

--- a/internal/format/formatter.go
+++ b/internal/format/formatter.go
@@ -108,6 +108,15 @@ func FormatSignalSummary(m model.Metric) string {
 	return "(" + startLabel + " -> " + endLabel + ")"
 }
 
+// FormatStringSlice formats a string slice as a YAML-style inline array.
+func FormatStringSlice(ss []string) string {
+	quoted := make([]string, len(ss))
+	for i, s := range ss {
+		quoted[i] = fmt.Sprintf("%q", s)
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
+}
+
 // shortSignal returns a short display name for a signal constant.
 func shortSignal(signal string) string {
 	// Strip the common prefixes for brevity

--- a/internal/github/discover.go
+++ b/internal/github/discover.go
@@ -122,3 +122,79 @@ func (c *Client) DiscoverProjects(ctx context.Context) ([]DiscoveredProject, err
 
 	return projects, nil
 }
+
+// DiscoverProjectByNumber fetches a single Projects v2 board by its number,
+// including its fields and single-select options.
+func (c *Client) DiscoverProjectByNumber(ctx context.Context, number int) (*DiscoveredProject, error) {
+	query := `query($owner: String!, $repo: String!, $number: Int!) {
+		repository(owner: $owner, name: $repo) {
+			projectV2(number: $number) {
+				id
+				title
+				number
+				fields(first: 30) {
+					nodes {
+						... on ProjectV2SingleSelectField {
+							__typename
+							id
+							name
+							options {
+								id
+								name
+							}
+						}
+						... on ProjectV2Field {
+							__typename
+							id
+							name
+						}
+						... on ProjectV2IterationField {
+							__typename
+							id
+							name
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	variables := map[string]interface{}{
+		"owner":  c.owner,
+		"repo":   c.repo,
+		"number": number,
+	}
+
+	var resp struct {
+		Repository struct {
+			ProjectV2 *discoverProjectNode `json:"projectV2"`
+		} `json:"repository"`
+	}
+	if err := c.gql.DoWithContext(ctx, query, variables, &resp); err != nil {
+		return nil, fmt.Errorf("discover project #%d for %s/%s: %w", number, c.owner, c.repo, err)
+	}
+
+	p := resp.Repository.ProjectV2
+	if p == nil {
+		return nil, fmt.Errorf("project #%d not found on %s/%s", number, c.owner, c.repo)
+	}
+
+	proj := &DiscoveredProject{
+		ID:     p.ID,
+		Title:  p.Title,
+		Number: p.Number,
+	}
+	for _, f := range p.Fields.Nodes {
+		field := DiscoveredField{
+			ID:   f.ID,
+			Name: f.Name,
+			Type: f.Typename,
+		}
+		if len(f.Options) > 0 {
+			field.Options = f.Options
+		}
+		proj.Fields = append(proj.Fields, field)
+	}
+
+	return proj, nil
+}

--- a/internal/github/labels.go
+++ b/internal/github/labels.go
@@ -1,0 +1,34 @@
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// ListLabels returns all label names for the repository.
+func (c *Client) ListLabels(ctx context.Context) ([]string, error) {
+	var allLabels []string
+	page := 1
+
+	for {
+		var labels []struct {
+			Name string `json:"name"`
+		}
+
+		err := c.rest.Get(fmt.Sprintf("repos/%s/%s/labels?per_page=100&page=%d", c.owner, c.repo, page), &labels)
+		if err != nil {
+			return nil, fmt.Errorf("list labels for %s/%s: %w", c.owner, c.repo, err)
+		}
+
+		for _, l := range labels {
+			allLabels = append(allLabels, l.Name)
+		}
+
+		if len(labels) < 100 {
+			break
+		}
+		page++
+	}
+
+	return allLabels, nil
+}

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -199,6 +199,36 @@ out=$($BINARY status --help 2>&1)
 show "$out"
 [[ "$out" == *"wip"* ]] && pass "status help shows wip" || fail "status help shows wip"
 
+# ── config preflight ──────────────────────────────────────────────
+echo ""
+echo "config preflight (cli/cli, no project board)"
+
+out=$($BINARY config preflight -R cli/cli 2>&1)
+show "$out"
+[[ "$out" == *"quality:"* ]] && pass "preflight generates quality config" || fail "preflight generates quality config"
+[[ "$out" == *"cycle_time:"* ]] && pass "preflight generates cycle_time config" || fail "preflight generates cycle_time config"
+[[ "$out" == *"bug_labels:"* ]] && pass "preflight detects bug labels" || fail "preflight detects bug labels"
+
+out=$($BINARY config preflight -R cli/cli -f json 2>/dev/null)
+echo "$out" | jq '.strategy' 2>/dev/null | sed 's/^/    strategy: /'
+echo "$out" | jq -e '.repo' >/dev/null 2>&1 && pass "preflight json" || fail "preflight json"
+
+# ── help examples ─────────────────────────────────────────────────
+echo ""
+echo "help examples"
+
+out=$($BINARY flow lead-time --help 2>&1)
+[[ "$out" == *"Examples:"* ]] && pass "lead-time has examples" || fail "lead-time has examples"
+
+out=$($BINARY flow cycle-time --help 2>&1)
+[[ "$out" == *"Examples:"* ]] && pass "cycle-time has examples" || fail "cycle-time has examples"
+
+out=$($BINARY report --help 2>&1)
+[[ "$out" == *"Examples:"* ]] && pass "report has examples" || fail "report has examples"
+
+out=$($BINARY config preflight --help 2>&1)
+[[ "$out" == *"Examples:"* ]] && pass "preflight has examples" || fail "preflight has examples"
+
 # ── error cases ────────────────────────────────────────────────────
 echo ""
 echo "error handling"
@@ -219,10 +249,7 @@ show "$out"
 out=$($BINARY flow cycle-time --pr 1 --since 30d -R cli/cli 2>&1) && fail "pr+since should fail" || pass "flow cycle-time pr+since conflict rejected"
 show "$out"
 
-out=$($BINARY --post flow lead-time 2 -R cli/cli 2>&1) && fail "--post should fail" || pass "--post rejected"
-show "$out"
-
-out=$($BINARY flow lead-time 2 -R cli/cli -f json --post 2>&1 || true)
+out=$($BINARY flow lead-time abc -R cli/cli -f json 2>&1 || true)
 show "$out"
 echo "$out" | jq -e '.error.code' >/dev/null 2>&1 && pass "json error envelope" || fail "json error envelope"
 


### PR DESCRIPTION
## Summary

- **`config preflight`** — new command that analyzes a repo's labels, project board, and recent activity to generate a tailored `.gh-velocity.yml` with explanatory comments
  - `--project N` queries a specific Projects v2 board (avoids querying all projects)
  - `--write` saves the generated config directly
  - Classifies labels into bug/feature/active/backlog buckets
  - Detects cycle time strategy from PR vs issue activity patterns
- **Help examples** on every command (lead-time, cycle-time, release, report, preflight, config subcommands)
- **Improved error messages** that guide users toward `config create`, `config preflight`, or `config discover`
- **README rewrite** with clear onboarding flow and updated command tree
- **62 smoke tests** covering preflight, help examples, and error handling

Closes #11

## Test plan

- [x] `task test` — all unit tests pass
- [x] `task quality` — lint + staticcheck clean
- [x] `scripts/smoke-test.sh` — all 62 smoke tests pass
- [ ] Manual: `gh velocity config preflight -R cli/cli` generates sensible config
- [ ] Manual: `gh velocity config preflight -R dvhthomas/gh-velocity --project 1` detects project board

🤖 Generated with [Claude Code](https://claude.com/claude-code)