### PR TITLE
feat(project): resolve project URL and status field name at runtime

### DIFF
--- a/docs/plans/2026-03-11-feat-scope-lifecycle-filtering-plan.md
+++ b/docs/plans/2026-03-11-feat-scope-lifecycle-filtering-plan.md
@@ -197,9 +197,9 @@ func ParseProjectURL(rawURL string) (owner string, number int, isOrg bool, err e
 func (c *Client) ResolveProject(ctx context.Context, projectURL, statusFieldName string) (projectID, statusFieldID string, err error)
 ```
 
-- [ ] Add `ParseProjectURL()` in `internal/github/project.go`
-- [ ] Add `ResolveProject()` GraphQL query to get node ID + status field ID by visible name
-- [ ] Tests for URL parsing (user projects, org projects, invalid URLs)
+- [x] Add `ParseProjectURL()` in `internal/github/project.go`
+- [x] Add `ResolveProject()` GraphQL query to get node ID + status field ID by visible name
+- [x] Tests for URL parsing (user projects, org projects, invalid URLs)
 
 ### Phase 2: Refactor search API to accept assembled queries
 

--- a/internal/github/project.go
+++ b/internal/github/project.go
@@ -1,0 +1,70 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// ProjectInfo holds the resolved IDs needed for project board API calls.
+type ProjectInfo struct {
+	ProjectID     string // PVT_... node ID
+	StatusFieldID string // PVTSSF_... field ID
+}
+
+// ParseProjectURL extracts the owner, project number, and owner type from a GitHub project URL.
+// Accepts:
+//   - https://github.com/users/{user}/projects/{N}
+//   - https://github.com/orgs/{org}/projects/{N}
+func ParseProjectURL(rawURL string) (owner string, number int, isOrg bool, err error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", 0, false, fmt.Errorf("invalid project URL: %w", err)
+	}
+	if u.Host != "github.com" {
+		return "", 0, false, fmt.Errorf("project URL must be a github.com URL, got host %q", u.Host)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	// Expected: users/{user}/projects/{N} or orgs/{org}/projects/{N}
+	if len(parts) != 4 || (parts[0] != "users" && parts[0] != "orgs") || parts[2] != "projects" {
+		return "", 0, false, fmt.Errorf("project URL must be https://github.com/users/{user}/projects/{N} or https://github.com/orgs/{org}/projects/{N}, got %q", rawURL)
+	}
+	n, err := strconv.Atoi(parts[3])
+	if err != nil {
+		return "", 0, false, fmt.Errorf("project URL must end with a project number, got %q", parts[3])
+	}
+	return parts[1], n, parts[0] == "orgs", nil
+}
+
+// ResolveProject resolves a GitHub project URL and status field name to their internal IDs.
+// It fetches the project by number via GraphQL, then finds the named status field.
+func (c *Client) ResolveProject(ctx context.Context, projectURL, statusFieldName string) (*ProjectInfo, error) {
+	_, number, _, err := ParseProjectURL(projectURL)
+	if err != nil {
+		return nil, err
+	}
+
+	project, err := c.DiscoverProjectByNumber(ctx, number)
+	if err != nil {
+		return nil, fmt.Errorf("resolve project: %w", err)
+	}
+
+	info := &ProjectInfo{
+		ProjectID: project.ID,
+	}
+
+	if statusFieldName == "" {
+		return info, nil
+	}
+
+	for _, f := range project.Fields {
+		if strings.EqualFold(f.Name, statusFieldName) && len(f.Options) > 0 {
+			info.StatusFieldID = f.ID
+			return info, nil
+		}
+	}
+
+	return nil, fmt.Errorf("resolve project: status field %q not found on project %q (#%d)", statusFieldName, project.Title, project.Number)
+}

--- a/internal/github/project_test.go
+++ b/internal/github/project_test.go
@@ -1,0 +1,85 @@
+package github
+
+import "testing"
+
+func TestParseProjectURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		wantOwner  string
+		wantNumber int
+		wantIsOrg  bool
+		wantErr    bool
+	}{
+		{
+			name:       "user project",
+			url:        "https://github.com/users/dvhthomas/projects/1",
+			wantOwner:  "dvhthomas",
+			wantNumber: 1,
+			wantIsOrg:  false,
+		},
+		{
+			name:       "org project",
+			url:        "https://github.com/orgs/myorg/projects/42",
+			wantOwner:  "myorg",
+			wantNumber: 42,
+			wantIsOrg:  true,
+		},
+		{
+			name:    "wrong host",
+			url:     "https://gitlab.com/users/test/projects/1",
+			wantErr: true,
+		},
+		{
+			name:    "wrong path structure",
+			url:     "https://github.com/owner/repo",
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric project number",
+			url:     "https://github.com/users/test/projects/abc",
+			wantErr: true,
+		},
+		{
+			name:    "wrong segment",
+			url:     "https://github.com/teams/test/projects/1",
+			wantErr: true,
+		},
+		{
+			name:    "empty URL",
+			url:     "",
+			wantErr: true,
+		},
+		{
+			name:       "trailing slash",
+			url:        "https://github.com/users/test/projects/5/",
+			wantOwner:  "test",
+			wantNumber: 5,
+			wantIsOrg:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, number, isOrg, err := ParseProjectURL(tt.url)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if owner != tt.wantOwner {
+				t.Errorf("owner = %q, want %q", owner, tt.wantOwner)
+			}
+			if number != tt.wantNumber {
+				t.Errorf("number = %d, want %d", number, tt.wantNumber)
+			}
+			if isOrg != tt.wantIsOrg {
+				t.Errorf("isOrg = %v, want %v", isOrg, tt.wantIsOrg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Phase 1c of scope & lifecycle filtering (#18). Add ParseProjectURL() and ResolveProject() to resolve GitHub project URLs to internal IDs via GraphQL. Table-driven tests for URL parsing. Closes #22.