### PR TITLE
feat: actionable output phase 1 — links, labels, RenderContext

### DIFF
--- a/cmd/cycletime.go
+++ b/cmd/cycletime.go
@@ -142,7 +142,7 @@ func runCycleTimePR(cmd *cobra.Command, prNumber int) error {
 		Context: "pr-" + strconv.Itoa(prNumber),
 		Target:  posting.PRComment,
 		Number:  prNumber,
-	}, ct, warnings, "PR", prNumber, pr.Title, pr.State)
+	}, ct, warnings, "PR", prNumber, pr.Title, pr.State, pr.URL, pr.Labels)
 }
 
 // runCycleTimeIssue computes cycle time for an issue using the configured strategy.
@@ -189,7 +189,7 @@ func runCycleTimeIssue(cmd *cobra.Command, issueNumber int) error {
 		Context: strconv.Itoa(issueNumber),
 		Target:  posting.IssueComment,
 		Number:  issueNumber,
-	}, ct, warnings, "Issue", issueNumber, issue.Title, issue.State)
+	}, ct, warnings, "Issue", issueNumber, issue.Title, issue.State, issue.URL, issue.Labels)
 }
 
 // runCycleTimeBulk computes cycle time for all issues closed in a date window.
@@ -227,6 +227,7 @@ func runCycleTimeBulk(cmd *cobra.Command, sinceStr, untilStr string) error {
 	}
 
 	issueQuery := scope.ClosedIssueQuery(deps.Scope, since, until)
+	issueQuery.ExcludeUsers = deps.ExcludeUsers
 	if deps.Debug {
 		log.Debug("cycle-time issue query:\n%s", issueQuery.Verbose())
 	}
@@ -241,6 +242,7 @@ func runCycleTimeBulk(cmd *cobra.Command, sinceStr, untilStr string) error {
 	closingPRs := make(map[int]*model.PR)
 	if deps.Config.CycleTime.Strategy == "pr" {
 		prQuery := scope.MergedPRQuery(deps.Scope, since, until)
+		prQuery.ExcludeUsers = deps.ExcludeUsers
 		if deps.Debug {
 			log.Debug("cycle-time PR query:\n%s", prQuery.Verbose())
 		}
@@ -283,9 +285,9 @@ func runCycleTimeBulk(cmd *cobra.Command, sinceStr, untilStr string) error {
 	case format.JSON:
 		fmtErr = format.WriteCycleTimeBulkJSON(w, repo, since, until, deps.Config.CycleTime.Strategy, items, stats)
 	case format.Markdown:
-		fmtErr = format.WriteCycleTimeBulkMarkdown(w, repo, since, until, deps.Config.CycleTime.Strategy, items, stats)
+		fmtErr = format.WriteCycleTimeBulkMarkdown(deps.RenderCtx(w), repo, since, until, deps.Config.CycleTime.Strategy, items, stats)
 	default:
-		fmtErr = format.WriteCycleTimeBulkPretty(w, deps.IsTTY, deps.TermWidth, repo, since, until, deps.Config.CycleTime.Strategy, items, stats)
+		fmtErr = format.WriteCycleTimeBulkPretty(deps.RenderCtx(w), repo, since, until, deps.Config.CycleTime.Strategy, items, stats)
 	}
 	if fmtErr != nil {
 		return fmtErr
@@ -294,7 +296,7 @@ func runCycleTimeBulk(cmd *cobra.Command, sinceStr, untilStr string) error {
 }
 
 // outputCycleTime renders cycle-time results in the requested format and optionally posts.
-func outputCycleTime(cmd *cobra.Command, deps *Deps, client *gh.Client, postOpts posting.PostOptions, ct model.Metric, warnings []string, kind string, number int, title, state string) error {
+func outputCycleTime(cmd *cobra.Command, deps *Deps, client *gh.Client, postOpts posting.PostOptions, ct model.Metric, warnings []string, kind string, number int, title, state, itemURL string, labels []string) error {
 	w, postFn := postIfEnabled(cmd, deps, client, postOpts)
 	repo := deps.Owner + "/" + deps.Repo
 
@@ -306,14 +308,14 @@ func outputCycleTime(cmd *cobra.Command, deps *Deps, client *gh.Client, postOpts
 	switch deps.Format {
 	case format.JSON:
 		if kind == "PR" {
-			fmtErr = format.WriteCycleTimePRJSON(w, repo, number, title, state, ct, warnings)
+			fmtErr = format.WriteCycleTimePRJSON(w, repo, number, title, state, itemURL, labels, ct, warnings)
 		} else {
-			fmtErr = format.WriteCycleTimeJSON(w, repo, number, title, state, ct, warnings)
+			fmtErr = format.WriteCycleTimeJSON(w, repo, number, title, state, itemURL, labels, ct, warnings)
 		}
 	case format.Markdown:
-		fmtErr = format.WriteCycleTimeMarkdown(w, kind, number, title, ct)
+		fmtErr = format.WriteCycleTimeMarkdown(deps.RenderCtx(w), kind, number, title, itemURL, ct)
 	default:
-		fmtErr = format.WriteCycleTimePretty(w, kind, number, title, deps.Config.CycleTime.Strategy, ct)
+		fmtErr = format.WriteCycleTimePretty(deps.RenderCtx(w), kind, number, title, itemURL, deps.Config.CycleTime.Strategy, ct)
 	}
 	if fmtErr != nil {
 		return fmtErr

--- a/cmd/leadtime.go
+++ b/cmd/leadtime.go
@@ -102,15 +102,17 @@ func runLeadTimeSingle(cmd *cobra.Command, arg string) error {
 	})
 	switch deps.Format {
 	case format.JSON:
-		if err = format.WriteLeadTimeJSON(w, deps.Owner+"/"+deps.Repo, issueNumber, issue.Title, issue.State, lt, nil); err != nil {
+		if err = format.WriteLeadTimeJSON(w, deps.Owner+"/"+deps.Repo, issueNumber, issue.Title, issue.State, issue.URL, issue.Labels, lt, nil); err != nil {
 			return err
 		}
 	case format.Markdown:
+		rc := deps.RenderCtx(w)
 		fmt.Fprintf(w, "| Issue | Title | Created (UTC) | Lead Time |\n")
 		fmt.Fprintf(w, "| ---: | --- | --- | --- |\n")
-		fmt.Fprintf(w, "| #%d | %s | %s | %s |\n", issueNumber, issue.Title, issue.CreatedAt.UTC().Format(time.DateOnly), format.FormatMetric(lt))
+		fmt.Fprintf(w, "| %s | %s | %s | %s |\n", format.FormatItemLink(issueNumber, issue.URL, rc), issue.Title, issue.CreatedAt.UTC().Format(time.DateOnly), format.FormatMetric(lt))
 	default:
-		fmt.Fprintf(w, "Issue #%d  %s\n", issueNumber, issue.Title)
+		rc := deps.RenderCtx(w)
+		fmt.Fprintf(w, "Issue %s  %s\n", format.FormatItemLink(issueNumber, issue.URL, rc), issue.Title)
 		fmt.Fprintf(w, "  Created:   %s UTC\n", issue.CreatedAt.UTC().Format(time.RFC3339))
 		fmt.Fprintf(w, "  Lead Time: %s\n", format.FormatMetric(lt))
 	}
@@ -153,6 +155,7 @@ func runLeadTimeBulk(cmd *cobra.Command, sinceStr, untilStr string) error {
 	}
 
 	q := scope.ClosedIssueQuery(deps.Scope, since, until)
+	q.ExcludeUsers = deps.ExcludeUsers
 	if deps.Debug {
 		log.Debug("lead-time query:\n%s", q.Verbose())
 	}
@@ -187,9 +190,9 @@ func runLeadTimeBulk(cmd *cobra.Command, sinceStr, untilStr string) error {
 	case format.JSON:
 		fmtErr = format.WriteLeadTimeBulkJSON(w, repo, since, until, items, stats)
 	case format.Markdown:
-		fmtErr = format.WriteLeadTimeBulkMarkdown(w, repo, since, until, items, stats)
+		fmtErr = format.WriteLeadTimeBulkMarkdown(deps.RenderCtx(w), repo, since, until, items, stats)
 	default:
-		fmtErr = format.WriteLeadTimeBulkPretty(w, deps.IsTTY, deps.TermWidth, repo, since, until, items, stats)
+		fmtErr = format.WriteLeadTimeBulkPretty(deps.RenderCtx(w), repo, since, until, items, stats)
 	}
 	if fmtErr != nil {
 		return fmtErr

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -125,9 +125,9 @@ linking strategy discovered for the release.`,
 			case format.JSON:
 				fmtErr = format.WriteReleaseJSON(w, deps.Owner+"/"+deps.Repo, rm, warnings)
 			case format.Markdown:
-				fmtErr = format.WriteReleaseMarkdown(w, rm, warnings)
+				fmtErr = format.WriteReleaseMarkdown(deps.RenderCtx(w), rm, warnings)
 			default:
-				fmtErr = format.WriteReleasePretty(w, deps.IsTTY, deps.TermWidth, rm, warnings)
+				fmtErr = format.WriteReleasePretty(deps.RenderCtx(w), rm, warnings)
 			}
 			if fmtErr != nil {
 				return fmtErr

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -102,9 +102,9 @@ unavailable.`,
 			case format.JSON:
 				fmtErr = format.WriteReportJSON(w, result)
 			case format.Markdown:
-				fmtErr = format.WriteReportMarkdown(w, result)
+				fmtErr = format.WriteReportMarkdown(deps.RenderCtx(w), result)
 			default:
-				fmtErr = format.WriteReportPretty(w, deps.IsTTY, deps.TermWidth, result)
+				fmtErr = format.WriteReportPretty(deps.RenderCtx(w), result)
 			}
 			if fmtErr != nil {
 				return fmtErr

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -36,10 +37,23 @@ type Deps struct {
 	Owner        string
 	Repo         string
 	Scope        string // merged config + flag scope (GitHub search query fragment)
+	ExcludeUsers string // "-author:bot1 -author:bot2" exclusion qualifiers from config
 	HasLocalRepo bool   // true when a local git checkout is available
 	IsTTY        bool   // true when stdout is a terminal
 	TermWidth    int    // terminal width in columns (0 = unknown)
 	Debug        bool   // true when --debug is set
+}
+
+// RenderCtx builds a format.RenderContext from Deps and a writer.
+func (d *Deps) RenderCtx(w io.Writer) format.RenderContext {
+	return format.RenderContext{
+		Writer: w,
+		Format: d.Format,
+		IsTTY:  d.IsTTY,
+		Width:  d.TermWidth,
+		Owner:  d.Owner,
+		Repo:   d.Repo,
+	}
 }
 
 // DepsFromContext extracts Deps from the command context.
@@ -222,6 +236,7 @@ func NewRootCmd(version, buildTime string) *cobra.Command {
 				Owner:        owner,
 				Repo:         repo,
 				Scope:        resolvedScope,
+				ExcludeUsers: scope.BuildExclusions(cfg.ExcludeUsers),
 				HasLocalRepo: hasLocal,
 				IsTTY:        isTTY,
 				TermWidth:    termWidth,

--- a/cmd/throughput.go
+++ b/cmd/throughput.go
@@ -73,7 +73,9 @@ Default window is the last 30 days.`,
 			}
 
 			issueQuery := scope.ClosedIssueQuery(deps.Scope, since, until)
+			issueQuery.ExcludeUsers = deps.ExcludeUsers
 			prQuery := scope.MergedPRQuery(deps.Scope, since, until)
+			prQuery.ExcludeUsers = deps.ExcludeUsers
 			if deps.Debug {
 				log.Debug("throughput issue query:\n%s", issueQuery.Verbose())
 				log.Debug("throughput PR query:\n%s", prQuery.Verbose())

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/bitsbyme/gh-velocity
 go 1.25.8
 
 require (
+	github.com/charmbracelet/x/ansi v0.8.0
 	github.com/cli/go-gh/v2 v2.13.0
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/spf13/cobra v1.10.2
@@ -15,7 +16,6 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250319133953-166f707985bc // indirect
-	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/cli/safeexec v1.0.0 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,14 +31,15 @@ var WarnFunc = func(format string, args ...any) {
 
 // Config represents the .gh-velocity.yml configuration.
 type Config struct {
-	Workflow    string            `yaml:"workflow" json:"workflow"`
-	Scope       ScopeConfig       `yaml:"scope" json:"scope"`
-	Project     ProjectConfig     `yaml:"project" json:"project"`
-	Lifecycle   LifecycleConfig   `yaml:"lifecycle" json:"lifecycle"`
-	Quality     QualityConfig     `yaml:"quality" json:"quality"`
-	Discussions DiscussionsConfig `yaml:"discussions" json:"discussions"`
-	CommitRef   CommitRefConfig   `yaml:"commit_ref" json:"commit_ref"`
-	CycleTime   CycleTimeConfig   `yaml:"cycle_time" json:"cycle_time"`
+	Workflow     string            `yaml:"workflow" json:"workflow"`
+	Scope        ScopeConfig       `yaml:"scope" json:"scope"`
+	Project      ProjectConfig     `yaml:"project" json:"project"`
+	Lifecycle    LifecycleConfig   `yaml:"lifecycle" json:"lifecycle"`
+	Quality      QualityConfig     `yaml:"quality" json:"quality"`
+	Discussions  DiscussionsConfig `yaml:"discussions" json:"discussions"`
+	CommitRef    CommitRefConfig   `yaml:"commit_ref" json:"commit_ref"`
+	CycleTime    CycleTimeConfig   `yaml:"cycle_time" json:"cycle_time"`
+	ExcludeUsers []string          `yaml:"exclude_users" json:"exclude_users"`
 }
 
 // ScopeConfig holds the user's scope query — a GitHub search query fragment.
@@ -176,14 +177,15 @@ func defaults() *Config {
 
 // knownTopLevelKeys lists the YAML keys that map to Config struct fields.
 var knownTopLevelKeys = map[string]bool{
-	"workflow":    true,
-	"scope":       true,
-	"project":     true,
-	"lifecycle":   true,
-	"quality":     true,
-	"discussions": true,
-	"commit_ref":  true,
-	"cycle_time":  true,
+	"workflow":      true,
+	"scope":         true,
+	"project":       true,
+	"lifecycle":     true,
+	"quality":       true,
+	"discussions":   true,
+	"commit_ref":    true,
+	"cycle_time":    true,
+	"exclude_users": true,
 }
 
 // warnUnknownKeysFromMap warns about any top-level keys in the parsed map
@@ -296,7 +298,6 @@ func validate(cfg *Config) error {
 
 	return nil
 }
-
 
 // resolveCategories ensures cfg.Quality.Categories is populated.
 // If the user specified explicit categories, those are used (and a warning

--- a/internal/format/bulk.go
+++ b/internal/format/bulk.go
@@ -34,6 +34,8 @@ type jsonWindow struct {
 type jsonBulkLeadItem struct {
 	Number   int        `json:"number"`
 	Title    string     `json:"title"`
+	URL      string     `json:"url,omitempty"`
+	Labels   []string   `json:"labels,omitempty"`
 	LeadTime JSONMetric `json:"lead_time"`
 }
 
@@ -54,6 +56,8 @@ func WriteLeadTimeBulkJSON(w io.Writer, repo string, since, until time.Time, ite
 		out.Items = append(out.Items, jsonBulkLeadItem{
 			Number:   item.Issue.Number,
 			Title:    item.Issue.Title,
+			URL:      item.Issue.URL,
+			Labels:   item.Issue.Labels,
 			LeadTime: metricToJSON(item.Metric),
 		})
 	}
@@ -66,50 +70,52 @@ func WriteLeadTimeBulkJSON(w io.Writer, repo string, since, until time.Time, ite
 // --- Markdown ---
 
 // WriteLeadTimeBulkMarkdown writes bulk lead-time results as a markdown table.
-func WriteLeadTimeBulkMarkdown(w io.Writer, repo string, since, until time.Time, items []BulkLeadTimeItem, stats model.Stats) error {
+func WriteLeadTimeBulkMarkdown(rc RenderContext, repo string, since, until time.Time, items []BulkLeadTimeItem, stats model.Stats) error {
 	sorted := sortByCloseDateDesc(items)
 
-	fmt.Fprintf(w, "## Lead Time: %s (%s – %s UTC)\n\n",
+	fmt.Fprintf(rc.Writer, "## Lead Time: %s (%s – %s UTC)\n\n",
 		repo, since.UTC().Format(time.DateOnly), until.UTC().Format(time.DateOnly))
 
-	fmt.Fprintf(w, "| Issue | Title | Created (UTC) | Closed (UTC) | Lead Time |\n")
-	fmt.Fprintf(w, "| ---: | --- | --- | --- | --- |\n")
+	fmt.Fprintf(rc.Writer, "| Issue | Title | Labels | Created (UTC) | Closed (UTC) | Lead Time |\n")
+	fmt.Fprintf(rc.Writer, "| ---: | --- | --- | --- | --- | --- |\n")
 	for _, item := range sorted {
 		closedStr := "N/A"
 		if item.Issue.ClosedAt != nil {
 			closedStr = item.Issue.ClosedAt.UTC().Format(time.DateOnly)
 		}
-		fmt.Fprintf(w, "| #%d | %s | %s | %s | %s |\n",
-			item.Issue.Number,
+		fmt.Fprintf(rc.Writer, "| %s | %s | %s | %s | %s | %s |\n",
+			FormatItemLink(item.Issue.Number, item.Issue.URL, rc),
 			sanitizeMarkdown(item.Issue.Title),
+			FormatLabels(item.Issue.Labels),
 			item.Issue.CreatedAt.UTC().Format(time.DateOnly),
 			closedStr,
 			FormatMetricDuration(item.Metric),
 		)
 	}
 
-	fmt.Fprintf(w, "\n**Summary:** %s\n", formatStatsSummary(stats))
+	fmt.Fprintf(rc.Writer, "\n**Summary:** %s\n", formatStatsSummary(stats))
 	return nil
 }
 
 // --- Pretty ---
 
 // WriteLeadTimeBulkPretty writes bulk lead-time results as a formatted table.
-func WriteLeadTimeBulkPretty(w io.Writer, isTTY bool, width int, repo string, since, until time.Time, items []BulkLeadTimeItem, stats model.Stats) error {
+func WriteLeadTimeBulkPretty(rc RenderContext, repo string, since, until time.Time, items []BulkLeadTimeItem, stats model.Stats) error {
 	sorted := sortByCloseDateDesc(items)
 
-	fmt.Fprintf(w, "Lead Time: %s (%s – %s UTC)\n\n",
+	fmt.Fprintf(rc.Writer, "Lead Time: %s (%s – %s UTC)\n\n",
 		repo, since.UTC().Format(time.DateOnly), until.UTC().Format(time.DateOnly))
 
-	tp := NewTable(w, isTTY, width)
-	tp.AddHeader([]string{"#", "Title", "Created", "Closed", "Lead Time"})
+	tp := NewTable(rc.Writer, rc.IsTTY, rc.Width)
+	tp.AddHeader([]string{"#", "Title", "Labels", "Created", "Closed", "Lead Time"})
 	for _, item := range sorted {
 		closedStr := "N/A"
 		if item.Issue.ClosedAt != nil {
 			closedStr = item.Issue.ClosedAt.UTC().Format(time.DateOnly)
 		}
-		tp.AddField(fmt.Sprintf("%d", item.Issue.Number))
+		tp.AddField(FormatItemLink(item.Issue.Number, item.Issue.URL, rc))
 		tp.AddField(item.Issue.Title)
+		tp.AddField(FormatLabels(item.Issue.Labels))
 		tp.AddField(item.Issue.CreatedAt.UTC().Format(time.DateOnly))
 		tp.AddField(closedStr)
 		tp.AddField(FormatMetricDuration(item.Metric))
@@ -119,7 +125,7 @@ func WriteLeadTimeBulkPretty(w io.Writer, isTTY bool, width int, repo string, si
 		return err
 	}
 
-	fmt.Fprintf(w, "\n%s\n", formatStatsSummary(stats))
+	fmt.Fprintf(rc.Writer, "\n%s\n", formatStatsSummary(stats))
 	return nil
 }
 
@@ -147,6 +153,8 @@ type jsonBulkCycleTimeOutput struct {
 type jsonBulkCycleItem struct {
 	Number    int        `json:"number"`
 	Title     string     `json:"title"`
+	URL       string     `json:"url,omitempty"`
+	Labels    []string   `json:"labels,omitempty"`
 	CycleTime JSONMetric `json:"cycle_time"`
 }
 
@@ -168,6 +176,8 @@ func WriteCycleTimeBulkJSON(w io.Writer, repo string, since, until time.Time, st
 		out.Items = append(out.Items, jsonBulkCycleItem{
 			Number:    item.Issue.Number,
 			Title:     item.Issue.Title,
+			URL:       item.Issue.URL,
+			Labels:    item.Issue.Labels,
 			CycleTime: metricToJSON(item.Metric),
 		})
 	}
@@ -180,14 +190,14 @@ func WriteCycleTimeBulkJSON(w io.Writer, repo string, since, until time.Time, st
 // --- Cycle Time Markdown ---
 
 // WriteCycleTimeBulkMarkdown writes bulk cycle-time results as a markdown table.
-func WriteCycleTimeBulkMarkdown(w io.Writer, repo string, since, until time.Time, strategy string, items []BulkCycleTimeItem, stats model.Stats) error {
+func WriteCycleTimeBulkMarkdown(rc RenderContext, repo string, since, until time.Time, strategy string, items []BulkCycleTimeItem, stats model.Stats) error {
 	sorted := sortCycleByCloseDateDesc(items)
 
-	fmt.Fprintf(w, "## Cycle Time: %s (%s – %s UTC) [%s]\n\n",
+	fmt.Fprintf(rc.Writer, "## Cycle Time: %s (%s – %s UTC) [%s]\n\n",
 		repo, since.UTC().Format(time.DateOnly), until.UTC().Format(time.DateOnly), strategy)
 
-	fmt.Fprintf(w, "| Issue | Title | Started (UTC) | Closed (UTC) | Cycle Time |\n")
-	fmt.Fprintf(w, "| ---: | --- | --- | --- | --- |\n")
+	fmt.Fprintf(rc.Writer, "| Issue | Title | Labels | Started (UTC) | Closed (UTC) | Cycle Time |\n")
+	fmt.Fprintf(rc.Writer, "| ---: | --- | --- | --- | --- | --- |\n")
 	for _, item := range sorted {
 		startedStr := "N/A"
 		if item.Metric.Start != nil {
@@ -197,30 +207,31 @@ func WriteCycleTimeBulkMarkdown(w io.Writer, repo string, since, until time.Time
 		if item.Issue.ClosedAt != nil {
 			closedStr = item.Issue.ClosedAt.UTC().Format(time.DateOnly)
 		}
-		fmt.Fprintf(w, "| #%d | %s | %s | %s | %s |\n",
-			item.Issue.Number,
+		fmt.Fprintf(rc.Writer, "| %s | %s | %s | %s | %s | %s |\n",
+			FormatItemLink(item.Issue.Number, item.Issue.URL, rc),
 			sanitizeMarkdown(item.Issue.Title),
+			FormatLabels(item.Issue.Labels),
 			startedStr,
 			closedStr,
 			FormatMetricDuration(item.Metric),
 		)
 	}
 
-	fmt.Fprintf(w, "\n**Summary:** %s\n", formatStatsSummary(stats))
+	fmt.Fprintf(rc.Writer, "\n**Summary:** %s\n", formatStatsSummary(stats))
 	return nil
 }
 
 // --- Cycle Time Pretty ---
 
 // WriteCycleTimeBulkPretty writes bulk cycle-time results as a formatted table.
-func WriteCycleTimeBulkPretty(w io.Writer, isTTY bool, width int, repo string, since, until time.Time, strategy string, items []BulkCycleTimeItem, stats model.Stats) error {
+func WriteCycleTimeBulkPretty(rc RenderContext, repo string, since, until time.Time, strategy string, items []BulkCycleTimeItem, stats model.Stats) error {
 	sorted := sortCycleByCloseDateDesc(items)
 
-	fmt.Fprintf(w, "Cycle Time: %s (%s – %s UTC) [%s]\n\n",
+	fmt.Fprintf(rc.Writer, "Cycle Time: %s (%s – %s UTC) [%s]\n\n",
 		repo, since.UTC().Format(time.DateOnly), until.UTC().Format(time.DateOnly), strategy)
 
-	tp := NewTable(w, isTTY, width)
-	tp.AddHeader([]string{"#", "Title", "Started", "Closed", "Cycle Time"})
+	tp := NewTable(rc.Writer, rc.IsTTY, rc.Width)
+	tp.AddHeader([]string{"#", "Title", "Labels", "Started", "Closed", "Cycle Time"})
 	for _, item := range sorted {
 		startedStr := "N/A"
 		if item.Metric.Start != nil {
@@ -230,8 +241,9 @@ func WriteCycleTimeBulkPretty(w io.Writer, isTTY bool, width int, repo string, s
 		if item.Issue.ClosedAt != nil {
 			closedStr = item.Issue.ClosedAt.UTC().Format(time.DateOnly)
 		}
-		tp.AddField(fmt.Sprintf("%d", item.Issue.Number))
+		tp.AddField(FormatItemLink(item.Issue.Number, item.Issue.URL, rc))
 		tp.AddField(item.Issue.Title)
+		tp.AddField(FormatLabels(item.Issue.Labels))
 		tp.AddField(startedStr)
 		tp.AddField(closedStr)
 		tp.AddField(FormatMetricDuration(item.Metric))
@@ -241,7 +253,7 @@ func WriteCycleTimeBulkPretty(w io.Writer, isTTY bool, width int, repo string, s
 		return err
 	}
 
-	fmt.Fprintf(w, "\n%s\n", formatStatsSummary(stats))
+	fmt.Fprintf(rc.Writer, "\n%s\n", formatStatsSummary(stats))
 	return nil
 }
 

--- a/internal/format/cycletime.go
+++ b/internal/format/cycletime.go
@@ -2,31 +2,30 @@ package format
 
 import (
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/bitsbyme/gh-velocity/internal/model"
 )
 
 // WriteCycleTimeMarkdown writes a single cycle-time result as a markdown table.
-func WriteCycleTimeMarkdown(w io.Writer, kind string, number int, title string, ct model.Metric) error {
-	fmt.Fprintf(w, "| %s | Title | Started (UTC) | Cycle Time |\n", kind)
-	fmt.Fprintf(w, "| ---: | --- | --- | --- |\n")
+func WriteCycleTimeMarkdown(rc RenderContext, kind string, number int, title, itemURL string, ct model.Metric) error {
+	fmt.Fprintf(rc.Writer, "| %s | Title | Started (UTC) | Cycle Time |\n", kind)
+	fmt.Fprintf(rc.Writer, "| ---: | --- | --- | --- |\n")
 	startedStr := "N/A"
 	if ct.Start != nil {
 		startedStr = ct.Start.Time.UTC().Format(time.DateOnly)
 	}
-	fmt.Fprintf(w, "| #%d | %s | %s | %s |\n", number, sanitizeMarkdown(title), startedStr, FormatMetric(ct))
+	fmt.Fprintf(rc.Writer, "| %s | %s | %s | %s |\n", FormatItemLink(number, itemURL, rc), sanitizeMarkdown(title), startedStr, FormatMetric(ct))
 	return nil
 }
 
 // WriteCycleTimePretty writes a single cycle-time result as formatted text.
-func WriteCycleTimePretty(w io.Writer, kind string, number int, title, strategy string, ct model.Metric) error {
-	fmt.Fprintf(w, "%s #%d  %s\n", kind, number, title)
-	fmt.Fprintf(w, "  Strategy:   %s\n", strategy)
+func WriteCycleTimePretty(rc RenderContext, kind string, number int, title, itemURL, strategy string, ct model.Metric) error {
+	fmt.Fprintf(rc.Writer, "%s %s  %s\n", kind, FormatItemLink(number, itemURL, rc), title)
+	fmt.Fprintf(rc.Writer, "  Strategy:   %s\n", strategy)
 	if ct.Start != nil {
-		fmt.Fprintf(w, "  Started:    %s UTC\n", ct.Start.Time.UTC().Format(time.RFC3339))
+		fmt.Fprintf(rc.Writer, "  Started:    %s UTC\n", ct.Start.Time.UTC().Format(time.RFC3339))
 	}
-	fmt.Fprintf(w, "  Cycle Time: %s\n", FormatMetric(ct))
+	fmt.Fprintf(rc.Writer, "  Cycle Time: %s\n", FormatMetric(ct))
 	return nil
 }

--- a/internal/format/formatter.go
+++ b/internal/format/formatter.go
@@ -3,11 +3,23 @@ package format
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
 	"github.com/bitsbyme/gh-velocity/internal/model"
 )
+
+// RenderContext consolidates common formatter parameters to prevent
+// parameter list explosion as output concerns (links, labels) grow.
+type RenderContext struct {
+	Writer io.Writer
+	Format Format
+	IsTTY  bool
+	Width  int
+	Owner  string // repository owner, for constructing URLs
+	Repo   string // repository name
+}
 
 // Format represents an output format type.
 type Format string

--- a/internal/format/formatter_test.go
+++ b/internal/format/formatter_test.go
@@ -149,7 +149,8 @@ func TestWriteReleaseMarkdown(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := WriteReleaseMarkdown(&buf, rm, nil); err != nil {
+	rc := RenderContext{Writer: &buf, Format: Markdown}
+	if err := WriteReleaseMarkdown(rc, rm, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/format/json.go
+++ b/internal/format/json.go
@@ -51,6 +51,8 @@ type JSONLeadTimeOutput struct {
 	Issue      int        `json:"issue"`
 	Title      string     `json:"title"`
 	State      string     `json:"state"`
+	URL        string     `json:"url,omitempty"`
+	Labels     []string   `json:"labels,omitempty"`
 	LeadTime   JSONMetric `json:"lead_time"`
 	Warnings   []string   `json:"warnings,omitempty"`
 }
@@ -62,6 +64,8 @@ type JSONCycleTimeOutput struct {
 	PR         int        `json:"pr,omitempty"`
 	Title      string     `json:"title"`
 	State      string     `json:"state"`
+	URL        string     `json:"url,omitempty"`
+	Labels     []string   `json:"labels,omitempty"`
 	CycleTime  JSONMetric `json:"cycle_time"`
 	Warnings   []string   `json:"warnings,omitempty"`
 }
@@ -94,6 +98,8 @@ type JSONCategoryComposition struct {
 type JSONIssueMetrics struct {
 	Number           int        `json:"number"`
 	Title            string     `json:"title"`
+	URL              string     `json:"url,omitempty"`
+	Labels           []string   `json:"labels,omitempty"`
 	Category         string     `json:"category"`
 	LeadTime         JSONMetric `json:"lead_time"`
 	CycleTime        JSONMetric `json:"cycle_time"`
@@ -121,12 +127,14 @@ type JSONStats struct {
 }
 
 // WriteLeadTimeJSON writes lead-time metrics as JSON to the writer.
-func WriteLeadTimeJSON(w io.Writer, repo string, issueNumber int, title, state string, m model.Metric, warnings []string) error {
+func WriteLeadTimeJSON(w io.Writer, repo string, issueNumber int, title, state, issueURL string, labels []string, m model.Metric, warnings []string) error {
 	out := JSONLeadTimeOutput{
 		Repository: repo,
 		Issue:      issueNumber,
 		Title:      title,
 		State:      state,
+		URL:        issueURL,
+		Labels:     labels,
 		LeadTime:   metricToJSON(m),
 		Warnings:   warnings,
 	}
@@ -136,12 +144,14 @@ func WriteLeadTimeJSON(w io.Writer, repo string, issueNumber int, title, state s
 }
 
 // WriteCycleTimeJSON writes cycle-time metrics for an issue as JSON to the writer.
-func WriteCycleTimeJSON(w io.Writer, repo string, issueNumber int, title, state string, m model.Metric, warnings []string) error {
+func WriteCycleTimeJSON(w io.Writer, repo string, issueNumber int, title, state, itemURL string, labels []string, m model.Metric, warnings []string) error {
 	out := JSONCycleTimeOutput{
 		Repository: repo,
 		Issue:      issueNumber,
 		Title:      title,
 		State:      state,
+		URL:        itemURL,
+		Labels:     labels,
 		CycleTime:  metricToJSON(m),
 		Warnings:   warnings,
 	}
@@ -151,12 +161,14 @@ func WriteCycleTimeJSON(w io.Writer, repo string, issueNumber int, title, state 
 }
 
 // WriteCycleTimePRJSON writes cycle-time metrics for a PR as JSON.
-func WriteCycleTimePRJSON(w io.Writer, repo string, prNumber int, title, state string, m model.Metric, warnings []string) error {
+func WriteCycleTimePRJSON(w io.Writer, repo string, prNumber int, title, state, itemURL string, labels []string, m model.Metric, warnings []string) error {
 	out := JSONCycleTimeOutput{
 		Repository: repo,
 		PR:         prNumber,
 		Title:      title,
 		State:      state,
+		URL:        itemURL,
+		Labels:     labels,
 		CycleTime:  metricToJSON(m),
 		Warnings:   warnings,
 	}
@@ -201,6 +213,8 @@ func WriteReleaseJSON(w io.Writer, repo string, rm model.ReleaseMetrics, warning
 		out.Issues = append(out.Issues, JSONIssueMetrics{
 			Number:           im.Issue.Number,
 			Title:            im.Issue.Title,
+			URL:              im.Issue.URL,
+			Labels:           im.Issue.Labels,
 			Category:         im.Category,
 			LeadTime:         metricToJSON(im.LeadTime),
 			CycleTime:        metricToJSON(im.CycleTime),

--- a/internal/format/links.go
+++ b/internal/format/links.go
@@ -1,0 +1,69 @@
+package format
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// FormatItemLink renders an issue/PR reference with a link appropriate to the format.
+// Uses OSC 8 hyperlinks for pretty/TTY, markdown links for markdown,
+// and plain text for non-TTY or when the URL is empty.
+func FormatItemLink(number int, url string, rc RenderContext) string {
+	text := fmt.Sprintf("#%d", number)
+	switch rc.Format {
+	case Markdown:
+		if url == "" {
+			return text
+		}
+		return fmt.Sprintf("[%s](%s)", text, stripControlChars(url))
+	case JSON:
+		return text // URL goes in separate JSON field
+	default: // Pretty
+		if !rc.IsTTY || url == "" {
+			return text
+		}
+		return ansi.SetHyperlink(stripControlChars(url)) + text + ansi.ResetHyperlink()
+	}
+}
+
+// FormatReleaseLink renders a release tag with a link appropriate to the format.
+func FormatReleaseLink(tag, url string, rc RenderContext) string {
+	switch rc.Format {
+	case Markdown:
+		if url == "" {
+			return tag
+		}
+		return fmt.Sprintf("[%s](%s)", tag, stripControlChars(url))
+	case JSON:
+		return tag
+	default:
+		if !rc.IsTTY || url == "" {
+			return tag
+		}
+		return ansi.SetHyperlink(stripControlChars(url)) + tag + ansi.ResetHyperlink()
+	}
+}
+
+// stripControlChars removes bytes 0x00-0x1f and 0x7f from text.
+// Prevents terminal escape sequence injection if untrusted text
+// is ever passed to hyperlink rendering.
+func stripControlChars(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r >= 0x20 && r != 0x7f {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// FormatLabels formats a label slice for display. Returns empty string if no labels.
+func FormatLabels(labels []string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	return strings.Join(labels, ", ")
+}

--- a/internal/format/links_test.go
+++ b/internal/format/links_test.go
@@ -1,0 +1,192 @@
+package format
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestFormatItemLink(t *testing.T) {
+	tests := []struct {
+		name   string
+		number int
+		url    string
+		rc     RenderContext
+		want   string
+	}{
+		{
+			name:   "markdown with URL",
+			number: 42,
+			url:    "https://github.com/owner/repo/issues/42",
+			rc:     RenderContext{Format: Markdown},
+			want:   "[#42](https://github.com/owner/repo/issues/42)",
+		},
+		{
+			name:   "markdown without URL",
+			number: 42,
+			url:    "",
+			rc:     RenderContext{Format: Markdown},
+			want:   "#42",
+		},
+		{
+			name:   "json ignores URL",
+			number: 42,
+			url:    "https://github.com/owner/repo/issues/42",
+			rc:     RenderContext{Format: JSON},
+			want:   "#42",
+		},
+		{
+			name:   "pretty non-TTY",
+			number: 42,
+			url:    "https://github.com/owner/repo/issues/42",
+			rc:     RenderContext{Format: Pretty, IsTTY: false},
+			want:   "#42",
+		},
+		{
+			name:   "pretty TTY without URL",
+			number: 42,
+			url:    "",
+			rc:     RenderContext{Format: Pretty, IsTTY: true},
+			want:   "#42",
+		},
+		{
+			name:   "pretty TTY with URL contains OSC8",
+			number: 42,
+			url:    "https://github.com/owner/repo/issues/42",
+			rc:     RenderContext{Format: Pretty, IsTTY: true},
+		},
+		{
+			name:   "URL with control chars stripped",
+			number: 1,
+			url:    "https://evil.com/\x1b[31mred",
+			rc:     RenderContext{Format: Markdown},
+			want:   "[#1](https://evil.com/[31mred)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatItemLink(tt.number, tt.url, tt.rc)
+			if tt.want != "" && got != tt.want {
+				t.Errorf("FormatItemLink() = %q, want %q", got, tt.want)
+			}
+			// For TTY with URL, just verify the link text is present
+			if tt.name == "pretty TTY with URL contains OSC8" {
+				if got == "#42" {
+					t.Error("expected OSC8 hyperlink, got plain text")
+				}
+			}
+		})
+	}
+}
+
+func TestFormatReleaseLink(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		url  string
+		rc   RenderContext
+		want string
+	}{
+		{
+			name: "markdown with URL",
+			tag:  "v1.0.0",
+			url:  "https://github.com/owner/repo/releases/tag/v1.0.0",
+			rc:   RenderContext{Format: Markdown},
+			want: "[v1.0.0](https://github.com/owner/repo/releases/tag/v1.0.0)",
+		},
+		{
+			name: "markdown without URL",
+			tag:  "v1.0.0",
+			url:  "",
+			rc:   RenderContext{Format: Markdown},
+			want: "v1.0.0",
+		},
+		{
+			name: "json ignores URL",
+			tag:  "v1.0.0",
+			url:  "https://github.com/owner/repo/releases/tag/v1.0.0",
+			rc:   RenderContext{Format: JSON},
+			want: "v1.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatReleaseLink(tt.tag, tt.url, tt.rc)
+			if got != tt.want {
+				t.Errorf("FormatReleaseLink() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripControlChars(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"clean string", "https://github.com", "https://github.com"},
+		{"null byte", "a\x00b", "ab"},
+		{"escape sequence", "a\x1b[31mb", "a[31mb"},
+		{"delete char", "a\x7fb", "ab"},
+		{"tab removed", "a\tb", "ab"},
+		{"newline removed", "a\nb", "ab"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripControlChars(tt.input)
+			if got != tt.want {
+				t.Errorf("stripControlChars(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels []string
+		want   string
+	}{
+		{"nil labels", nil, ""},
+		{"empty labels", []string{}, ""},
+		{"single label", []string{"bug"}, "bug"},
+		{"multiple labels", []string{"bug", "enhancement"}, "bug, enhancement"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatLabels(tt.labels)
+			if got != tt.want {
+				t.Errorf("FormatLabels() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderContext(t *testing.T) {
+	var buf bytes.Buffer
+	rc := RenderContext{
+		Writer: &buf,
+		Format: Pretty,
+		IsTTY:  true,
+		Width:  120,
+		Owner:  "owner",
+		Repo:   "repo",
+	}
+
+	if rc.Writer != &buf {
+		t.Error("Writer mismatch")
+	}
+	if rc.Format != Pretty {
+		t.Error("Format mismatch")
+	}
+	if !rc.IsTTY {
+		t.Error("IsTTY should be true")
+	}
+	if rc.Width != 120 {
+		t.Error("Width mismatch")
+	}
+}

--- a/internal/format/markdown.go
+++ b/internal/format/markdown.go
@@ -10,7 +10,7 @@ import (
 )
 
 // WriteReleaseMarkdown writes release metrics as a markdown table.
-func WriteReleaseMarkdown(w io.Writer, rm model.ReleaseMetrics, warnings []string) error {
+func WriteReleaseMarkdown(rc RenderContext, rm model.ReleaseMetrics, warnings []string) error {
 	var b strings.Builder
 
 	b.WriteString(fmt.Sprintf("## Release %s\n\n", rm.Tag))
@@ -37,17 +37,18 @@ func WriteReleaseMarkdown(w io.Writer, rm model.ReleaseMetrics, warnings []strin
 	// Per-issue table
 	if len(rm.Issues) > 0 {
 		b.WriteString("### Issues\n\n")
-		b.WriteString("| # | Title | Lead Time | Cycle Time | Release Lag | Commits | |\n")
-		b.WriteString("| ---: | --- | --- | --- | --- | ---: | --- |\n")
+		b.WriteString("| # | Title | Labels | Lead Time | Cycle Time | Release Lag | Commits | |\n")
+		b.WriteString("| ---: | --- | --- | --- | --- | --- | ---: | --- |\n")
 		for _, im := range rm.Issues {
 			title := sanitizeMarkdown(im.Issue.Title)
 			flag := ""
 			if im.LeadTimeOutlier || im.CycleTimeOutlier {
 				flag = "OUTLIER"
 			}
-			b.WriteString(fmt.Sprintf("| %d | %s | %s | %s | %s | %d | %s |\n",
-				im.Issue.Number,
+			b.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %d | %s |\n",
+				FormatItemLink(im.Issue.Number, im.Issue.URL, rc),
 				title,
+				FormatLabels(im.Issue.Labels),
 				FormatDurationPtr(im.LeadTime.Duration),
 				FormatDurationPtr(im.CycleTime.Duration),
 				FormatDurationPtr(im.ReleaseLag.Duration),
@@ -74,7 +75,7 @@ func WriteReleaseMarkdown(w io.Writer, rm model.ReleaseMetrics, warnings []strin
 		}
 	}
 
-	_, err := io.WriteString(w, b.String())
+	_, err := io.WriteString(rc.Writer, b.String())
 	return err
 }
 

--- a/internal/format/pretty.go
+++ b/internal/format/pretty.go
@@ -2,7 +2,6 @@ package format
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/bitsbyme/gh-velocity/internal/model"
@@ -10,7 +9,8 @@ import (
 )
 
 // WriteReleasePretty writes release metrics as a formatted table to the writer.
-func WriteReleasePretty(w io.Writer, isTTY bool, width int, rm model.ReleaseMetrics, warnings []string) error {
+func WriteReleasePretty(rc RenderContext, rm model.ReleaseMetrics, warnings []string) error {
+	w := rc.Writer
 	fmt.Fprintf(w, "Release %s\n", rm.Tag)
 	fmt.Fprintln(w, strings.Repeat("=", 60))
 	fmt.Fprintln(w)
@@ -35,15 +35,16 @@ func WriteReleasePretty(w io.Writer, isTTY bool, width int, rm model.ReleaseMetr
 	// Per-issue table
 	if len(rm.Issues) > 0 {
 		fmt.Fprintln(w, "Issues")
-		tp := NewTable(w, isTTY, width)
-		tp.AddHeader([]string{"#", "Title", "Lead Time", "Cycle Time", "Rel. Lag", "Commits", ""})
+		tp := NewTable(w, rc.IsTTY, rc.Width)
+		tp.AddHeader([]string{"#", "Title", "Labels", "Lead Time", "Cycle Time", "Rel. Lag", "Commits", ""})
 		for _, im := range rm.Issues {
 			flag := ""
 			if im.LeadTimeOutlier || im.CycleTimeOutlier {
 				flag = "OUTLIER"
 			}
-			tp.AddField(fmt.Sprintf("%d", im.Issue.Number))
+			tp.AddField(FormatItemLink(im.Issue.Number, im.Issue.URL, rc))
 			tp.AddField(im.Issue.Title)
+			tp.AddField(FormatLabels(im.Issue.Labels))
 			tp.AddField(FormatDurationPtr(im.LeadTime.Duration))
 			tp.AddField(FormatDurationPtr(im.CycleTime.Duration))
 			tp.AddField(FormatDurationPtr(im.ReleaseLag.Duration))
@@ -59,7 +60,7 @@ func WriteReleasePretty(w io.Writer, isTTY bool, width int, rm model.ReleaseMetr
 
 	// Aggregates
 	fmt.Fprintln(w, "Aggregates")
-	tp := NewTable(w, isTTY, width)
+	tp := NewTable(w, rc.IsTTY, rc.Width)
 	tp.AddHeader([]string{"Metric", "Mean", "Median", "Std Dev", "P90", "P95", "Outliers"})
 	writePrettyStatsRow(tp, "Lead Time", rm.LeadTimeStats)
 	writePrettyStatsRow(tp, "Cycle Time", rm.CycleTimeStats)

--- a/internal/format/report.go
+++ b/internal/format/report.go
@@ -82,7 +82,8 @@ func WriteReportJSON(w io.Writer, r model.StatsResult) error {
 // --- Markdown ---
 
 // WriteReportMarkdown writes dashboard metrics as markdown.
-func WriteReportMarkdown(w io.Writer, r model.StatsResult) error {
+func WriteReportMarkdown(rc RenderContext, r model.StatsResult) error {
+	w := rc.Writer
 	fmt.Fprintf(w, "## Report: %s (%s – %s UTC)\n\n",
 		r.Repository, r.Since.UTC().Format(time.DateOnly), r.Until.UTC().Format(time.DateOnly))
 
@@ -120,7 +121,8 @@ func WriteReportMarkdown(w io.Writer, r model.StatsResult) error {
 // --- Pretty ---
 
 // WriteReportPretty writes dashboard metrics as formatted text.
-func WriteReportPretty(w io.Writer, isTTY bool, width int, r model.StatsResult) error {
+func WriteReportPretty(rc RenderContext, r model.StatsResult) error {
+	w := rc.Writer
 	fmt.Fprintf(w, "Report: %s (%s – %s UTC)\n\n",
 		r.Repository, r.Since.UTC().Format(time.DateOnly), r.Until.UTC().Format(time.DateOnly))
 

--- a/internal/format/wip.go
+++ b/internal/format/wip.go
@@ -18,13 +18,15 @@ type jsonWIPOutput struct {
 }
 
 type jsonWIPItem struct {
-	Number     int    `json:"number,omitempty"`
-	Title      string `json:"title"`
-	Status     string `json:"status"`
-	AgeSeconds int64  `json:"age_seconds"`
-	Age        string `json:"age"`
-	Repo       string `json:"repo,omitempty"`
-	Kind       string `json:"kind"`
+	Number     int      `json:"number,omitempty"`
+	Title      string   `json:"title"`
+	URL        string   `json:"url,omitempty"`
+	Labels     []string `json:"labels,omitempty"`
+	Status     string   `json:"status"`
+	AgeSeconds int64    `json:"age_seconds"`
+	Age        string   `json:"age"`
+	Repo       string   `json:"repo,omitempty"`
+	Kind       string   `json:"kind"`
 }
 
 // WriteWIPJSON writes WIP items as JSON.
@@ -38,6 +40,8 @@ func WriteWIPJSON(w io.Writer, repo string, items []model.WIPItem) error {
 		out.Items = append(out.Items, jsonWIPItem{
 			Number:     item.Number,
 			Title:      item.Title,
+			URL:        item.URL,
+			Labels:     item.Labels,
 			Status:     item.Status,
 			AgeSeconds: int64(item.Age.Seconds()),
 			Age:        FormatDuration(item.Age),
@@ -53,51 +57,53 @@ func WriteWIPJSON(w io.Writer, repo string, items []model.WIPItem) error {
 // --- Markdown ---
 
 // WriteWIPMarkdown writes WIP items as a markdown table.
-func WriteWIPMarkdown(w io.Writer, repo string, items []model.WIPItem) error {
+func WriteWIPMarkdown(rc RenderContext, repo string, items []model.WIPItem) error {
 	sorted := sortWIPByAgeDesc(items)
 
-	fmt.Fprintf(w, "## Work in Progress: %s\n\n", repo)
-	fmt.Fprintf(w, "| # | Title | Status | Age | Kind |\n")
-	fmt.Fprintf(w, "| ---: | --- | --- | --- | --- |\n")
+	fmt.Fprintf(rc.Writer, "## Work in Progress: %s\n\n", repo)
+	fmt.Fprintf(rc.Writer, "| # | Title | Labels | Status | Age | Kind |\n")
+	fmt.Fprintf(rc.Writer, "| ---: | --- | --- | --- | --- | --- |\n")
 	for _, item := range sorted {
 		num := ""
 		if item.Number > 0 {
-			num = fmt.Sprintf("#%d", item.Number)
+			num = FormatItemLink(item.Number, item.URL, rc)
 		}
-		fmt.Fprintf(w, "| %s | %s | %s | %s | %s |\n",
+		fmt.Fprintf(rc.Writer, "| %s | %s | %s | %s | %s | %s |\n",
 			num,
 			sanitizeMarkdown(item.Title),
+			FormatLabels(item.Labels),
 			item.Status,
 			FormatDuration(item.Age),
 			item.Kind,
 		)
 	}
-	fmt.Fprintf(w, "\n**Count:** %d\n", len(items))
+	fmt.Fprintf(rc.Writer, "\n**Count:** %d\n", len(items))
 	return nil
 }
 
 // --- Pretty ---
 
 // WriteWIPPretty writes WIP items as a formatted table.
-func WriteWIPPretty(w io.Writer, isTTY bool, width int, repo string, items []model.WIPItem) error {
+func WriteWIPPretty(rc RenderContext, repo string, items []model.WIPItem) error {
 	sorted := sortWIPByAgeDesc(items)
 
-	fmt.Fprintf(w, "Work in Progress: %s (%d items)\n\n", repo, len(items))
+	fmt.Fprintf(rc.Writer, "Work in Progress: %s (%d items)\n\n", repo, len(items))
 
 	if len(sorted) == 0 {
-		fmt.Fprintln(w, "  No items in progress.")
+		fmt.Fprintln(rc.Writer, "  No items in progress.")
 		return nil
 	}
 
-	tp := NewTable(w, isTTY, width)
-	tp.AddHeader([]string{"#", "Title", "Status", "Age", "Kind"})
+	tp := NewTable(rc.Writer, rc.IsTTY, rc.Width)
+	tp.AddHeader([]string{"#", "Title", "Labels", "Status", "Age", "Kind"})
 	for _, item := range sorted {
 		num := ""
 		if item.Number > 0 {
-			num = fmt.Sprintf("%d", item.Number)
+			num = FormatItemLink(item.Number, item.URL, rc)
 		}
 		tp.AddField(num)
 		tp.AddField(item.Title)
+		tp.AddField(FormatLabels(item.Labels))
 		tp.AddField(item.Status)
 		tp.AddField(FormatDuration(item.Age))
 		tp.AddField(item.Kind)

--- a/internal/github/pullrequests.go
+++ b/internal/github/pullrequests.go
@@ -17,6 +17,7 @@ type searchIssueResponse struct {
 	Title     string     `json:"title"`
 	State     string     `json:"state"`
 	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
 	ClosedAt  *time.Time `json:"closed_at"`
 	HTMLURL   string     `json:"html_url"`
 	Labels    []struct {

--- a/internal/github/search.go
+++ b/internal/github/search.go
@@ -23,6 +23,7 @@ func searchItemToIssue(item searchIssueResponse) model.Issue {
 		State:     item.State,
 		Labels:    labels,
 		CreatedAt: item.CreatedAt.UTC(),
+		UpdatedAt: item.UpdatedAt.UTC(),
 		ClosedAt:  item.ClosedAt,
 		URL:       item.HTMLURL,
 	}
@@ -65,7 +66,20 @@ func (c *Client) searchPaginated(ctx context.Context, query string) ([]searchIss
 		path := fmt.Sprintf("search/issues?q=%s&per_page=100&page=%d",
 			url.QueryEscape(query), page)
 		if err := c.rest.DoWithContext(ctx, "GET", path, nil, &resp); err != nil {
-			return nil, err
+			if wait, ok := rateLimitWait(err); ok {
+				log.Warn("search rate-limited; waiting %s before retry", wait)
+				select {
+				case <-time.After(wait):
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				// Retry once after waiting.
+				if retryErr := c.rest.DoWithContext(ctx, "GET", path, nil, &resp); retryErr != nil {
+					return nil, retryErr
+				}
+			} else {
+				return nil, err
+			}
 		}
 
 		allItems = append(allItems, resp.Items...)

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -52,6 +52,7 @@ type Issue struct {
 	IssueType string // GitHub Issue Type (from GraphQL); empty for REST-sourced issues
 	CreatedAt time.Time
 	ClosedAt  *time.Time
+	UpdatedAt time.Time // last activity timestamp from GitHub
 	URL       string
 }
 
@@ -170,12 +171,15 @@ type ProjectItem struct {
 
 // WIPItem represents an in-progress work item for display.
 type WIPItem struct {
-	Number int
-	Title  string
-	Status string
-	Age    time.Duration
-	Repo   string // populated for cross-repo board views
-	Kind   string // "Issue", "PullRequest", "DraftIssue"
+	Number    int
+	Title     string
+	Status    string
+	Age       time.Duration
+	Repo      string // populated for cross-repo board views
+	Kind      string // "Issue", "PullRequest", "DraftIssue"
+	URL       string
+	Labels    []string
+	UpdatedAt time.Time // last activity timestamp, for staleness detection
 }
 
 // StatsResult holds all dashboard sections for output.

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -11,15 +11,16 @@ import (
 
 // Query holds the components of a search query.
 type Query struct {
-	Scope     string // user scope from config + flag
-	Lifecycle string // command lifecycle qualifiers (e.g., "is:closed closed:2026-01-01..2026-02-01")
-	Type      string // "is:issue" or "is:pr" (from strategy)
+	Scope        string // user scope from config + flag
+	Lifecycle    string // command lifecycle qualifiers (e.g., "is:closed closed:2026-01-01..2026-02-01")
+	Type         string // "is:issue" or "is:pr" (from strategy)
+	ExcludeUsers string // "-author:bot1 -author:bot2" exclusion qualifiers
 }
 
 // Build assembles the full search query string by joining non-empty parts.
 func (q Query) Build() string {
 	var parts []string
-	for _, p := range []string{q.Scope, q.Type, q.Lifecycle} {
+	for _, p := range []string{q.Scope, q.Type, q.Lifecycle, q.ExcludeUsers} {
 		if s := strings.TrimSpace(p); s != "" {
 			parts = append(parts, s)
 		}
@@ -48,11 +49,28 @@ func (q Query) Verbose() string {
 	if q.Lifecycle != "" {
 		fmt.Fprintf(&sb, "[lifecycle] %s\n", q.Lifecycle)
 	}
+	if q.ExcludeUsers != "" {
+		fmt.Fprintf(&sb, "[exclude]   %s\n", q.ExcludeUsers)
+	}
 	fmt.Fprintf(&sb, "[query]     %s\n", q.Build())
 	if u := q.URL(); u != "" {
 		fmt.Fprintf(&sb, "[url]       %s\n", u)
 	}
 	return sb.String()
+}
+
+// BuildExclusions builds a search qualifier string that excludes the given
+// usernames from results. Each user becomes a "-author:username" qualifier.
+// Returns empty string if no users are provided.
+func BuildExclusions(users []string) string {
+	if len(users) == 0 {
+		return ""
+	}
+	parts := make([]string, len(users))
+	for i, u := range users {
+		parts[i] = "-author:" + u
+	}
+	return strings.Join(parts, " ")
 }
 
 // ClosedIssueQuery returns a Query for issues closed in the given date range.


### PR DESCRIPTION
Closes #37

## Summary
Infrastructure foundation for actionable output features (Phase 1 of #36).

- RenderContext struct to consolidate formatter parameters
- Per-item clickable links (lipgloss TTY, markdown, JSON url field)
- Labels in item-listing output
- UpdatedAt on model.Issue and model.WIPItem
- Search retry wrapper using rateLimitWait
- exclude_users config for bot filtering
- stripControlChars defense-in-depth

## Test plan
- [ ] `task test`
- [ ] `task quality`
- [ ] New table-driven tests for links