### PR TITLE
feat: pre-release analysis skill and v0.0.2 docs fixes

### DIFF
--- a/.claude/skills/pre-release-analysis/SKILL.md
+++ b/.claude/skills/pre-release-analysis/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: pre-release-analysis
+description: Detects documentation drift, config mismatches, stale tests, and README inaccuracies before a release. Runs deterministic checks via scripts/prerelease-analysis.sh and performs semantic analysis that requires LLM reasoning.
+disable-model-invocation: true
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Agent
+---
+
+# Pre-Release Analysis
+
+Comprehensive consistency audit before tagging a release. Combines deterministic shell checks with semantic LLM analysis.
+
+## When to Use
+
+Run before any release tag. Invoked manually via `/pre-release-analysis` or as part of the release workflow.
+
+## Step 1: Run Deterministic Checks
+
+Execute the tool-agnostic analysis script:
+
+```bash
+bash scripts/prerelease-analysis.sh
+```
+
+This checks:
+- README command tree vs registered Cobra commands
+- Deprecated flags documented without deprecation notes
+- Quick Start claims vs actual config requirements
+- Config template round-trip validity
+- Example config validation
+- Smoke test currency (stale command names)
+- Smoke test coverage (untested commands)
+- Guide strategy names vs model constants
+- Guide config field names vs schema
+- Working tree cleanliness
+- Go test suite
+- Blocking TODOs/FIXMEs
+- goreleaser config
+
+## Step 2: Semantic Analysis (LLM-powered)
+
+The shell script catches structural mismatches. These checks catch semantic drift that requires reading comprehension:
+
+### 2a. README Accuracy
+
+Read `README.md` and cross-reference against actual behavior:
+
+1. **Installation instructions** — do they work with the current binary name and `gh extension install` flow?
+2. **Example output** — does sample output in README match what the tool actually produces? Run a command and compare.
+3. **Feature claims** — does README describe features that don't exist yet, or omit features that do exist?
+4. **Config examples** — do inline YAML snippets use current field names and valid values?
+
+### 2b. Guide Completeness
+
+Read `docs/guide.md` and check:
+
+1. **All commands documented** — every leaf command in the tree should have at least a mention
+2. **Config field coverage** — every config field in the Go structs should be explained
+3. **Workflow accuracy** — does the described workflow match how the tool actually works?
+
+### 2c. CHANGELOG / Release Notes Prep
+
+Check what changed since the last release tag:
+
+```bash
+# Changes since last tag
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [ -n "$LAST_TAG" ]; then
+    git log --oneline "$LAST_TAG"..HEAD
+fi
+```
+
+Flag any changes that should be called out in release notes (breaking changes, new commands, deprecations).
+
+## Output
+
+Present a unified report combining shell script output and semantic findings. Group by severity:
+
+1. **Blocking** — must fix before release (fail items from script + semantic errors)
+2. **Warnings** — should review (warn items from script + semantic concerns)
+3. **Passed** — confirmed correct
+
+Include file paths and line numbers for all findings.

--- a/README.md
+++ b/README.md
@@ -14,41 +14,41 @@ Requires [GitHub CLI](https://cli.github.com/) 2.0+.
 
 ## Quick start
 
-Try it now against any public repo — no config needed:
+A config file (`.gh-velocity.yml`) is required for all metric commands. Generate one first:
+
+```bash
+# 1. Analyze your repo and generate a tailored config
+gh velocity config preflight -R owner/repo --project-url https://github.com/users/you/projects/1
+
+# 2. Save it
+gh velocity config preflight --write --project-url https://github.com/users/you/projects/1
+
+# 3. Validate
+gh velocity config validate
+```
+
+Not sure which project URL to use? Run `gh velocity config discover -R owner/repo` to list them.
+
+Then run metrics:
 
 ```bash
 # How long do issues take to close? (last 30 days)
-gh velocity flow lead-time --since 30d -R cli/cli
+gh velocity flow lead-time --since 30d -R cli/cli --config docs/examples/cli-cli.yml
 
 # How did the last release go?
-gh velocity quality release v2.67.0 -R cli/cli --since v2.66.0
+gh velocity quality release v2.67.0 -R cli/cli --since v2.66.0 --config docs/examples/cli-cli.yml
 
 # Everything at a glance (composite dashboard)
-gh velocity report --since 30d -R cli/cli
+gh velocity report --since 30d -R cli/cli --config docs/examples/cli-cli.yml
 ```
 
-From inside your own repo, omit `-R`:
+From inside your own repo (with `.gh-velocity.yml` present), omit `-R` and `--config`:
 
 ```bash
 cd your-repo
 gh velocity flow lead-time 42
 gh velocity report
 ```
-
-### Set up your repo (optional but recommended)
-
-```bash
-# 1. Analyze your repo and generate a tailored config
-gh velocity config preflight -R owner/repo --project 3
-
-# 2. Save it
-gh velocity config preflight --write --project 3
-
-# 3. Validate
-gh velocity config validate
-```
-
-Not sure which project number to use? Run `gh velocity config discover -R owner/repo` to list them.
 
 ## Commands
 
@@ -60,19 +60,24 @@ gh velocity
 │   └── throughput [--since] [--until]
 │
 ├── quality                           # How good is our output?
-│   └── release <tag> [--since] [--scope]
+│   └── release <tag> [--since] [--discover]
+│
+├── risk                              # What should we watch?
+│   └── bus-factor [--since]          # Contributor concentration
 │
 ├── status                            # What's happening now?
-│   └── wip                           # Work in progress
+│   ├── wip                           # Work in progress
+│   ├── my-week [--since]             # Your recent activity
+│   └── reviews                       # PRs awaiting review
 │
 ├── report [--since] [--until]        # Composite dashboard
 │
 ├── config
-│   ├── preflight [-R repo] [--project N]  # Analyze repo, suggest config
-│   ├── create                             # Generate starter config
-│   ├── discover [-R repo]                 # Find project board IDs
-│   ├── show                               # Display resolved config
-│   └── validate                           # Check for errors
+│   ├── preflight [-R repo] [--project-url URL]  # Analyze repo, suggest config
+│   ├── create                                   # Generate starter config
+│   ├── discover [-R repo]                       # Find project board URLs
+│   ├── show                                     # Display resolved config
+│   └── validate                                 # Check for errors
 │
 └── version
 ```
@@ -160,9 +165,15 @@ jobs:
 - **Hotfix detection** — flag issues closed very close to release
 - **Aggregates** — mean, median, P90, P95, IQR-based outlier detection
 
+### Risk
+
+- **Bus factor** — contributor concentration risk (how spread is work across the team?)
+
 ### Status
 
 - **WIP** — items currently in progress (from Projects v2 board or labels)
+- **My Week** — your recent activity: issues closed, PRs merged, what's ahead
+- **Reviews** — PRs awaiting code review, with staleness detection (>48h)
 
 ### Report (composite dashboard)
 
@@ -177,20 +188,20 @@ Three strategies run in parallel to find which issues belong to a release:
 2. **commit-ref** — commit messages scanned for `fixes #N`, `closes #N`, `resolves #N`
 3. **changelog** — release body parsed for `#N` references
 
-Results merge with priority (pr-link > commit-ref > changelog). Use `--scope` to see what each strategy finds.
+Results merge with priority (pr-link > commit-ref > changelog). Use `--discover` to see what each strategy finds.
 
 ## Configuration
 
-All fields are optional. `gh velocity` works without a config file using sensible defaults.
+A config file (`.gh-velocity.yml`) is required for all metric commands. The fastest way to create one:
 
 ### Generate a tailored config
 
 ```bash
 # Preflight analyzes your repo's labels, project boards, and recent activity
-gh velocity config preflight -R owner/repo --project 3
+gh velocity config preflight -R owner/repo --project-url https://github.com/users/you/projects/1
 
 # Save directly
-gh velocity config preflight --write --project 3
+gh velocity config preflight --write --project-url https://github.com/users/you/projects/1
 ```
 
 ### Manual config
@@ -198,10 +209,17 @@ gh velocity config preflight --write --project 3
 Create `.gh-velocity.yml` in your repo root:
 
 ```yaml
-# Issue classification
+# Issue/PR classification — first matching category wins; unmatched = "other".
+# Matchers: label:<name>, type:<name>, title:/<regex>/i
 quality:
-  bug_labels: ["bug", "defect"]
-  feature_labels: ["enhancement"]
+  categories:
+    - name: bug
+      match:
+        - "label:bug"
+        - "label:defect"
+    - name: feature
+      match:
+        - "label:enhancement"
   hotfix_window_hours: 72
 
 # Commit message patterns
@@ -213,15 +231,21 @@ cycle_time:
   strategy: issue
 
 # Projects v2 board (enables WIP and lifecycle-based cycle time)
-# Find these IDs with: gh velocity config discover
+# Find your project URL with: gh velocity config discover -R owner/repo
 # project:
-#   id: "PVT_kwDOAbc123"
-#   status_field_id: "PVTSSF_kwDOAbc123"
+#   url: "https://github.com/users/yourname/projects/1"
+#   status_field: "Status"
 
-# Label-based status (alternative to project board)
-# statuses:
-#   active_labels: ["in-progress", "wip"]
-#   backlog_labels: ["backlog", "icebox"]
+# Lifecycle stages: map project board columns to workflow stages
+# lifecycle:
+#   backlog:
+#     project_status: ["Backlog", "Triage"]
+#   in-progress:
+#     project_status: ["In progress"]
+
+# Exclude bot accounts from metrics
+# exclude_users:
+#   - "dependabot[bot]"
 ```
 
 See [docs/guide.md](docs/guide.md) for the full configuration reference, metric definitions, and examples for popular OSS repos.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -114,6 +114,16 @@ tasks:
       - task: smoke
       - echo '✓ All quality checks passed'
 
+  # ── Release ──────────────────────────────────────────────────────
+
+  release:preflight:
+    desc: Pre-release validation (run before tagging)
+    cmds:
+      - task: quality
+      - task: e2e:configs
+      - bash scripts/prerelease-analysis.sh
+      - echo '✓ All pre-release checks passed — ready to tag'
+
   # ── Maintenance ────────────────────────────────────────────────────
 
   clean:

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -222,11 +222,13 @@ gh velocity version
 
 ### First queries
 
+All metric commands require a config file. When targeting a remote repo with `-R`, use `--config` to point at an example config (see `docs/examples/`). From inside your own repo with `.gh-velocity.yml` present, the config is loaded automatically.
+
 Start with a public repo to see what the output looks like:
 
 ```bash
 # Release report for the GitHub CLI itself
-gh velocity release v2.67.0 -R cli/cli
+gh velocity quality release v2.67.0 -R cli/cli
 ```
 
 This takes 10-30 seconds depending on the number of issues. You will see:
@@ -239,7 +241,7 @@ This takes 10-30 seconds depending on the number of issues. You will see:
 Try the same report in JSON to see the full data:
 
 ```bash
-gh velocity release v2.67.0 -R cli/cli -f json | jq '.aggregates.lead_time'
+gh velocity quality release v2.67.0 -R cli/cli -f json | jq '.aggregates.lead_time'
 ```
 
 ```json
@@ -258,7 +260,7 @@ gh velocity release v2.67.0 -R cli/cli -f json | jq '.aggregates.lead_time'
 See which strategy found each issue:
 
 ```bash
-gh velocity scope v2.67.0 -R cli/cli
+gh velocity quality release v2.67.0 -R cli/cli --discover
 ```
 
 This shows what `pr-link`, `commit-ref`, and `changelog` each discovered, and the merged result. Use this to understand how well the strategies cover your workflow.
@@ -269,7 +271,7 @@ From inside a local checkout, you can omit `-R`:
 
 ```bash
 cd your-repo
-gh velocity release v1.0.0
+gh velocity quality release v1.0.0
 ```
 
 When run from inside a repo, the tool uses local git for tag listing and commit history. This is faster and enables cycle-time computation.
@@ -280,7 +282,7 @@ When run from inside a repo, the tool uses local git for tag listing and commit 
 
 ```bash
 # Works without cloning — uses PR creation date, assignment, or project status
-gh velocity cycle-time 42 -R cli/cli
+gh velocity flow cycle-time 42 -R cli/cli
 ```
 
 If you run from inside a local checkout, the tool also counts commits referencing the issue and can use the earliest commit as a fallback start signal.
@@ -288,7 +290,7 @@ If you run from inside a local checkout, the tool also counts commits referencin
 ```bash
 # From inside a clone — enriched with commit count and fallback signal
 cd cli
-gh velocity cycle-time 42
+gh velocity flow cycle-time 42
 ```
 
 To enable project board-based cycle time (issue strategy), add project and lifecycle configuration:
@@ -318,7 +320,7 @@ The tool detects shallow clones and warns you.
 
 ## Configuration reference
 
-Create `.gh-velocity.yml` in your repository root. Every field is optional. The tool uses sensible defaults when no config file exists (which is the case when using `-R` against a remote repo).
+A `.gh-velocity.yml` file is required for all metric commands. Create one in your repository root, or use `--config` to point to an alternate path. Every field within the config is optional — the tool uses sensible defaults for anything you omit.
 
 ### Minimal config
 
@@ -440,7 +442,7 @@ gh velocity config show -f json
 
 ## Linking strategies in depth
 
-The `release` and `scope` commands need to determine which issues belong to a release. This is harder than it sounds — different teams use different workflows, and no single method works everywhere. `gh-velocity` uses three strategies and merges the results.
+The `quality release` and `quality release --discover` commands need to determine which issues belong to a release. This is harder than it sounds — different teams use different workflows, and no single method works everywhere. `gh-velocity` uses three strategies and merges the results.
 
 ### pr-link
 
@@ -489,10 +491,10 @@ Results from all three strategies are combined using priority-based deduplicatio
 
 When the same issue number appears in multiple strategies, the highest-priority version wins. This means pr-link's rich data (PR reference, full issue metadata) is preferred over commit-ref's issue-number-only data.
 
-The `scope` command shows this merge in action:
+The `--discover` flag shows this merge in action:
 
 ```bash
-gh velocity scope v1.2.0
+gh velocity quality release v1.2.0 --discover
 ```
 
 The output lists what each strategy found and marks items that appear in multiple strategies with "(also: commit-ref)" annotations.
@@ -507,7 +509,7 @@ An agent that reviews releases:
 
 ```bash
 # Get the full release report as JSON
-REPORT=$(gh velocity release v1.2.0 -R owner/repo -f json)
+REPORT=$(gh velocity quality release v1.2.0 -R owner/repo -f json)
 
 # Feed to an agent for analysis
 echo "$REPORT" | your-agent analyze-release
@@ -517,15 +519,15 @@ Extracting specific data with jq:
 
 ```bash
 # Which issues are outliers?
-gh velocity release v1.2.0 -f json | \
+gh velocity quality release v1.2.0 -f json | \
   jq '[.issues[] | select(.lead_time_outlier) | {number, title, lead_time_seconds}]'
 
 # What percentage are bugs?
-gh velocity release v1.2.0 -f json | \
+gh velocity quality release v1.2.0 -f json | \
   jq '.composition | "\(.bug_count)/\(.total_issues) bugs (\(.bug_ratio * 100 | round)%)"'
 
 # P95 lead time in days
-gh velocity release v1.2.0 -f json | \
+gh velocity quality release v1.2.0 -f json | \
   jq '.aggregates.lead_time.p95_seconds / 86400 | round | "\(.) days"'
 ```
 
@@ -535,11 +537,11 @@ The markdown format is designed for pasting into issues, PRs, or discussions:
 
 ```bash
 # Generate a release summary and post it as an issue comment
-gh velocity release v1.2.0 -f markdown | \
+gh velocity quality release v1.2.0 -f markdown | \
   gh issue comment 100 --body-file -
 
 # Or create a new issue with the report
-gh velocity release v1.2.0 -f markdown | \
+gh velocity quality release v1.2.0 -f markdown | \
   gh issue create --title "Release v1.2.0 metrics" --body-file -
 ```
 
@@ -552,9 +554,9 @@ You have access to `gh velocity`. Use it to analyze our last 3 releases
 and identify trends in lead time and bug ratio.
 
 Commands available:
-  gh velocity release <tag> -f json
-  gh velocity scope <tag> -f json
-  gh velocity lead-time <issue> -f json
+  gh velocity quality release<tag> -f json
+  gh velocity quality release <tag> --discover -f json
+  gh velocity flow lead-time<issue> -f json
 
 Our recent tags: v2.5.0, v2.4.0, v2.3.0
 ```
@@ -593,7 +595,7 @@ jobs:
 
       - name: Generate report
         run: |
-          gh velocity release ${{ github.event.release.tag_name }} -f markdown > report.md
+          gh velocity quality release${{ github.event.release.tag_name }} -f markdown > report.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -638,13 +640,14 @@ jobs:
         run: |
           # Parse PR body for "Fixes #N" or "Closes #N"
           ISSUE=$(echo "${{ github.event.pull_request.body }}" | \
-            grep -oP '(?:fixes|closes|resolves)\s+#\K\d+' -i | head -1)
+            grep -oiE '(fixes|closes|resolves)\s+#[0-9]+' | \
+            grep -oE '[0-9]+' | head -1)
           echo "number=$ISSUE" >> "$GITHUB_OUTPUT"
 
       - name: Report lead time
         if: steps.issue.outputs.number != ''
         run: |
-          gh velocity lead-time ${{ steps.issue.outputs.number }} -f markdown | \
+          gh velocity flow lead-time ${{ steps.issue.outputs.number }} -f markdown | \
             gh pr comment ${{ github.event.pull_request.number }} --body-file -
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -677,8 +680,8 @@ jobs:
       - name: Latest release metrics
         run: |
           TAG=$(git describe --tags --abbrev=0)
-          gh velocity release "$TAG" -f json > metrics.json
-          gh velocity release "$TAG" -f markdown > metrics.md
+          gh velocity quality release "$TAG" -f json > metrics.json
+          gh velocity quality release "$TAG" -f markdown > metrics.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -694,8 +697,8 @@ jobs:
 ### Compare two releases
 
 ```bash
-gh velocity release v2.0.0 -f json > v2.json
-gh velocity release v1.9.0 -f json > v1.json
+gh velocity quality release v2.0.0 -f json > v2.json
+gh velocity quality release v1.9.0 -f json > v1.json
 
 # Compare lead times
 echo "v1.9.0 median lead time: $(jq -r '.aggregates.lead_time.median_seconds / 86400 | round | "\(.)d"' v1.json)"
@@ -705,7 +708,7 @@ echo "v2.0.0 median lead time: $(jq -r '.aggregates.lead_time.median_seconds / 8
 ### Find your slowest issues
 
 ```bash
-gh velocity release v1.2.0 -f json | \
+gh velocity quality release v1.2.0 -f json | \
   jq -r '.issues | sort_by(-.lead_time_seconds) | .[0:5] | .[] |
     "#\(.number) \(.title[0:40]) — \(.lead_time_seconds / 86400 | round)d"'
 ```
@@ -713,7 +716,7 @@ gh velocity release v1.2.0 -f json | \
 ### Check label coverage before a release
 
 ```bash
-gh velocity release v1.2.0 -f json | \
+gh velocity quality release v1.2.0 -f json | \
   jq '"Bug: \(.composition.bug_count), Feature: \(.composition.feature_count), Unlabeled: \(.composition.other_count)"'
 ```
 
@@ -724,8 +727,8 @@ If `other_count` is high, label your issues before publishing the release for mo
 When the auto-detected previous tag is wrong (non-linear tag history, pre-releases), override it:
 
 ```bash
-gh velocity release v2.0.0 --since v1.9.0
-gh velocity scope v2.0.0 --since v1.9.0
+gh velocity quality release v2.0.0 --since v1.9.0
+gh velocity quality release v2.0.0 --since v1.9.0 --discover
 ```
 
 ### Analyze a repo you don't have locally
@@ -733,9 +736,9 @@ gh velocity scope v2.0.0 --since v1.9.0
 Every command works with `-R`:
 
 ```bash
-gh velocity release v0.28.0 -R charmbracelet/bubbletea
-gh velocity lead-time 500 -R charmbracelet/bubbletea
-gh velocity scope v5.2.1 -R go-chi/chi
+gh velocity quality release v0.28.0 -R charmbracelet/bubbletea
+gh velocity flow lead-time 500 -R charmbracelet/bubbletea
+gh velocity quality release v5.2.1 -R go-chi/chi --discover
 ```
 
 All commands work remotely. Cycle time uses API-based signals (PR creation date, first assignment). A local checkout adds commit counts and a fallback signal from commit history.
@@ -745,7 +748,7 @@ All commands work remotely. Cycle time uses API-based signals (PR creation date,
 ```bash
 for tag in $(gh api repos/owner/repo/tags --jq '.[].name' | head -5); do
   echo "=== $tag ==="
-  gh velocity release "$tag" -R owner/repo 2>/dev/null
+  gh velocity quality release "$tag" -R owner/repo 2>/dev/null
   echo
 done
 ```
@@ -753,7 +756,7 @@ done
 ### Export to CSV for spreadsheet analysis
 
 ```bash
-gh velocity release v1.2.0 -f json | \
+gh velocity quality release v1.2.0 -f json | \
   jq -r '["number","title","lead_time_days","cycle_time_days","outlier"],
     (.issues[] | [
       .number,

--- a/docs/plans/2026-03-12-005-feat-v002-release-readiness-plan.md
+++ b/docs/plans/2026-03-12-005-feat-v002-release-readiness-plan.md
@@ -1,0 +1,126 @@
+---
+title: "v0.0.2 Release Readiness"
+type: feat
+status: active
+date: 2026-03-12
+---
+
+# v0.0.2 Release Readiness
+
+## Overview
+
+Ship the next release of gh-velocity so the author can install and use it on `dvhthomas/gh-velocity` and `CalcMark/go-calcmark`. This is a patch release (v0.0.2) or pre-release (v0.0.2-rc.1) — not a minor bump.
+
+Since v0.0.1 (2026-03-11), 20+ commits landed: pipeline interface, config-required, bus-factor, reviews, my-week, actionable output, cycle-time strategy refactor, JSON warnings completeness, and docs refresh.
+
+## Pre-Release Checklist
+
+### Phase 1: Merge outstanding work
+
+- [ ] Merge PR #48 (`fix/first-run-experience`) to main
+- [ ] Delete the `fix/first-run-experience` and `refactor/cycle-time-strategy-rework` remote branches
+
+### Phase 2: Fix stale smoke-test-ext.sh
+
+`scripts/smoke-test-ext.sh` uses v0.0.1-era command names that no longer exist. Every line using `gh velocity lead-time`, `gh velocity scope`, or `gh velocity release` (without `quality` prefix) will fail against the current binary.
+
+- [ ] Rewrite `smoke-test-ext.sh` to use current command hierarchy:
+  - `gh velocity lead-time ...` → `gh velocity flow lead-time ...`
+  - `gh velocity scope ...` → `gh velocity quality release --discover ...`
+  - `gh velocity release ...` → `gh velocity quality release ...`
+  - `gh velocity lead-time abc ...` (error test) → `gh velocity flow lead-time abc ...`
+- [ ] Add missing commands to ext smoke tests: `flow cycle-time`, `flow throughput`, `risk bus-factor`, `status reviews`, `report`
+- [ ] Run `task install && task test:integration` and verify all pass
+
+### Phase 3: Fix README Quick Start vs config-required
+
+The README says "no config needed" for Quick Start but config IS required since the config-required change. Two options:
+
+**Option A (recommended):** Update the Quick Start to include a config step:
+```bash
+# Try it now against any public repo:
+gh velocity config preflight -R cli/cli --write
+gh velocity flow lead-time --since 30d -R cli/cli
+```
+
+**Option B:** Allow configless fallback for remote repos (`-R`). This contradicts the design decision that config is required.
+
+- [ ] Update README Quick Start (lines 17-36) — add config creation step
+- [ ] Update README CI example (lines 119-135) — add comment that `.gh-velocity.yml` must be committed
+- [ ] Fix README config example (line 42): `--project 3` → `--project-url <url>` (the `--project` flag is deprecated per `cmd/preflight.go:152-153`)
+- [ ] Update command tree in README (lines 55-78) to include `risk bus-factor`, `status reviews`, `status my-week`
+- [ ] Remove stale config fields from README manual config section (lines 200-225):
+  - `bug_labels`/`feature_labels` → replaced by `quality.categories` with matchers
+  - `project.id`/`status_field_id` → replaced by `project.url`/`status_field`
+
+### Phase 4: Verify goreleaser name template for Windows
+
+The `.goreleaser.yml` name_template is `{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}` without `{{ .Ext }}`. goreleaser's `binary` archive format should auto-append `.exe` for Windows, but verify:
+
+- [ ] Check that v0.0.1 GitHub Release has Windows assets with `.exe` extension. If not, add `{{ .Ext }}` to the template.
+
+### Phase 5: Configure and validate on target repos
+
+#### dvhthomas/gh-velocity (this repo)
+
+- [ ] Verify `.gh-velocity.yml` root config is current (no dead fields like `lifecycle.done.query`, config fields match current schema)
+- [ ] Run `gh velocity config validate` — should pass
+- [ ] Run `gh velocity report --since 30d` — should produce output
+- [ ] Run `gh velocity flow lead-time --since 30d` — should produce output
+- [ ] Run `gh velocity status my-week --since 14d` — should produce output
+
+#### CalcMark/go-calcmark
+
+- [ ] Run `gh velocity config preflight -R CalcMark/go-calcmark` to see what's suggested
+- [ ] The repo has a GitHub Project "CalcMark Tracker" with 26 items — preflight should detect it
+- [ ] Run `gh velocity config preflight -R CalcMark/go-calcmark --project-url <project-url> --write` from inside the go-calcmark checkout
+- [ ] Run `gh velocity config validate` in go-calcmark
+- [ ] Run `gh velocity report --since 30d` in go-calcmark
+- [ ] Run `gh velocity status my-week --since 14d` in go-calcmark
+
+### Phase 6: Run full test suite
+
+- [ ] `go test ./... -count=1 -race` — all pass
+- [ ] `task quality` — lint + vet pass
+- [ ] `task smoke` — smoke tests pass against built binary
+- [ ] `task install && task test:integration` — extension smoke tests pass
+
+### Phase 7: Tag and release
+
+- [ ] Decide: `v0.0.2` (patch) or `v0.0.2-rc.1` (pre-release)
+- [ ] `git tag v0.0.2 && git push origin v0.0.2` (goreleaser auto-triggered)
+- [ ] Wait for GitHub Actions release workflow to complete
+- [ ] Verify `gh extension upgrade dvhthomas/gh-velocity` picks up new version
+- [ ] Verify `gh velocity version` shows correct version
+
+### Phase 8: Post-release validation
+
+- [ ] `gh extension install dvhthomas/gh-velocity` on a clean machine (or after `gh extension remove gh-velocity`)
+- [ ] Follow the README Quick Start steps — they should work exactly as documented
+- [ ] Run `gh velocity report --since 30d -R dvhthomas/gh-velocity` — should produce real output
+
+## Acceptance Criteria
+
+- [ ] `gh extension install dvhthomas/gh-velocity` installs the new release
+- [ ] `gh velocity version` reports v0.0.2
+- [ ] `gh velocity config preflight -R CalcMark/go-calcmark` works and suggests reasonable config
+- [ ] README Quick Start steps work end-to-end without errors
+- [ ] `smoke-test-ext.sh` passes with current command names
+- [ ] JSON output from all commands includes `warnings` field
+
+## Known non-goals for v0.0.2
+
+- No CHANGELOG.md (goreleaser generates release notes from commits)
+- No deprecation aliases for old top-level commands (`lead-time`, `scope`, etc.) — only `release` has one
+- No `gh velocity version --check-update` feature
+- WIP command still requires project board config (TODO for future)
+
+## Sources
+
+- PR #48: `fix/first-run-experience` branch (6 commits)
+- `.goreleaser.yml` — release automation config
+- `.github/workflows/release.yml` — triggered on `v*` tags
+- `scripts/smoke-test.sh` — current (393 lines, 92+ assertions)
+- `scripts/smoke-test-ext.sh` — **stale**, needs rewrite
+- `README.md` — needs updates for config-required, command tree, config fields
+- `docs/guide.md` — already updated in PR #48

--- a/docs/plans/2026-03-12-006-feat-prerelease-analysis-skill-and-release-task-plan.md
+++ b/docs/plans/2026-03-12-006-feat-prerelease-analysis-skill-and-release-task-plan.md
@@ -1,0 +1,177 @@
+---
+title: "Pre-Release Analysis Skill and Release Task"
+type: feat
+status: active
+date: 2026-03-12
+---
+
+# Pre-Release Analysis Skill and Release Task
+
+## Overview
+
+Build a Claude Code skill (`pre-release-analysis`) that detects documentation drift, config schema mismatches, stale examples, README inaccuracies, and smoke test coverage gaps — all the nuances that accumulate between releases. Pair it with a `task release` Taskfile target that runs the full quality + analysis pipeline before tagging.
+
+## Problem Statement
+
+Between v0.0.1 and now, multiple documentation inconsistencies crept in unnoticed:
+- README Quick Start says "no config needed" but config IS required
+- README references `--project 3` (deprecated flag, should be `--project-url`)
+- README command tree is missing 3 commands (`risk bus-factor`, `status reviews`, `status my-week`)
+- README manual config section uses old field names (`bug_labels`, `project.id`)
+- `smoke-test-ext.sh` uses v0.0.1-era command names that no longer exist
+- The `.gh-velocity.yml` root config has dead fields
+
+These are caught by human review or by running the tool and seeing failures. A skill should catch them systematically.
+
+## Proposed Solution
+
+### 1. Pre-Release Analysis Skill (`.claude/skills/pre-release-analysis/SKILL.md`)
+
+A Claude Code skill that performs a comprehensive consistency audit. It checks:
+
+#### A. README ↔ Code Consistency
+- [ ] **Command tree accuracy**: Parse the command tree block in README and compare against actual Cobra commands registered in `cmd/root.go`. Flag missing or extra commands.
+- [ ] **Flag documentation**: Check that flags mentioned in README (e.g., `--project N`) match actual flag definitions in `cmd/*.go` (grep for `Flags().StringVar`, `Flags().IntVar`, etc.). Flag deprecated flags documented without deprecation notes.
+- [ ] **Quick Start validity**: Extract code blocks from README Quick Start section. Check each command against `--help` output to verify it would parse. Flag any command that requires config if README says "no config needed."
+- [ ] **Config schema accuracy**: Compare YAML fields shown in README's manual config section against the Go struct tags in `internal/model/types.go` and `internal/config/config.go`. Flag fields that don't exist in the schema or are missing from docs.
+
+#### B. Config Template ↔ Schema Consistency
+- [ ] **`defaultConfigTemplate` validity**: The template string in `cmd/config.go` should parse as valid YAML and pass `config validate`. Run a round-trip check.
+- [ ] **Example configs**: Each file in `docs/examples/*.yml` should parse without validation errors. Run `config validate` equivalent against each.
+- [ ] **Root `.gh-velocity.yml`**: Should have no dead/deprecated fields. Cross-reference against config validation warnings.
+
+#### C. Smoke Test Coverage
+- [ ] **Command coverage**: List all Cobra commands from `cmd/root.go`. For each, check that at least one smoke test in `scripts/smoke-test.sh` exercises it. Flag untested commands.
+- [ ] **Extension test currency**: Compare commands tested in `smoke-test-ext.sh` against current command names. Flag any that use old/removed command names.
+- [ ] **Format coverage**: For each command that supports `--format`, check that smoke tests cover pretty, json, and markdown.
+
+#### D. Guide ↔ Code Consistency
+- [ ] **`docs/guide.md` config field names**: Extract YAML field references from guide and check against schema structs.
+- [ ] **Strategy names**: Verify strategy names in guide match constants in `internal/model/types.go`.
+
+#### E. Version and Release Readiness
+- [ ] **Uncommitted changes**: `git status` should be clean (or only have expected files).
+- [ ] **All tests pass**: `go test ./... -count=1 -race` exits 0.
+- [ ] **No TODO(release)**: Grep for `TODO.*release` or `FIXME` in Go source — flag any blocking items.
+- [ ] **goreleaser dry-run**: If goreleaser is available, `goreleaser check` validates the config.
+
+#### Skill Output Format
+
+The skill should output a structured report:
+
+```
+Pre-Release Analysis
+====================
+
+README Consistency
+  ✓ Command tree matches registered commands
+  ✗ Quick Start says "no config needed" but config is required (README.md:17)
+  ✗ Flag --project is deprecated, use --project-url (README.md:42)
+  ✗ Missing commands in tree: risk bus-factor, status reviews, status my-week
+
+Config Consistency
+  ✓ defaultConfigTemplate parses and validates
+  ✗ Root .gh-velocity.yml has deprecated field: lifecycle.done.query
+  ✓ docs/examples/cli-cli.yml validates
+
+Smoke Test Coverage
+  ✗ smoke-test-ext.sh uses removed command: "gh velocity lead-time" (line 66)
+  ✗ smoke-test-ext.sh uses removed command: "gh velocity scope" (line 79)
+  ✓ All commands have at least one smoke test in smoke-test.sh
+
+Guide Consistency
+  ✓ Config field names match schema
+  ✓ Strategy names match model constants
+
+Release Readiness
+  ✓ Working tree clean
+  ✓ All tests pass
+  ✓ No blocking TODOs
+
+Summary: 4 issues found, 3 blocking
+```
+
+Each finding includes the file and line number for easy navigation.
+
+### 2. `task release` in Taskfile.yaml
+
+A new Taskfile target that runs the full pre-release pipeline:
+
+```yaml
+# Taskfile.yaml addition
+release:preflight:
+  desc: Pre-release validation (run before tagging)
+  cmds:
+    - task: quality
+    - task: e2e:configs
+    - task: test:integration
+    - echo '✓ All pre-release checks passed — ready to tag'
+```
+
+This runs sequentially (per AGENTS.md convention):
+1. `quality` (tidy, modernize, test, lint, staticcheck, vulncheck, graphql-injection, smoke)
+2. `e2e:configs` (validate example configs against real repos)
+3. `test:integration` (extension smoke tests via `smoke-test-ext.sh`)
+
+The skill runs separately via Claude Code (not in Taskfile) because it needs LLM reasoning to compare README prose against code semantics. The Taskfile handles deterministic checks; the skill handles fuzzy/semantic checks.
+
+## Acceptance Criteria
+
+### Skill
+- [x] `.claude/skills/pre-release-analysis/SKILL.md` exists with frontmatter
+- [x] Skill checks README command tree against registered Cobra commands
+- [x] Skill checks README Quick Start commands parse correctly
+- [x] Skill checks config fields in README match Go schema structs
+- [x] Skill checks `defaultConfigTemplate` round-trips through config validation
+- [x] Skill checks example configs validate
+- [x] Skill checks smoke-test-ext.sh uses current command names
+- [x] Skill checks docs/guide.md field names match schema
+- [x] Skill outputs structured report with file:line references
+- [x] Skill flags blocking vs non-blocking issues
+
+### Taskfile
+- [x] `task release:preflight` exists and runs: quality → e2e:configs → prerelease-analysis
+- [x] `task release:preflight` fails fast on first error (sequential cmds)
+- [ ] Running `task release:preflight` catches real issues in the current codebase
+
+### Validation
+- [x] Run the skill against the current codebase — it should find the known issues (README Quick Start lie, stale smoke-test-ext.sh, missing commands in README tree)
+- [ ] Run `task release:preflight` — it should fail on `test:integration` because `smoke-test-ext.sh` is stale
+- [ ] After fixing all issues, both the skill and `task release:preflight` should pass clean
+
+## Implementation Notes
+
+### Skill Structure
+
+```
+.claude/skills/pre-release-analysis/
+└── SKILL.md
+```
+
+Follow the pattern from `github-project-workflow/SKILL.md`:
+- `disable-model-invocation: true` (user invokes explicitly)
+- Allowed tools: Bash, Read, Grep, Glob, Agent
+- No Write/Edit — this is read-only analysis, not auto-fix
+
+### Key Files to Inspect
+
+| Check | Files |
+|-------|-------|
+| Cobra commands | `cmd/root.go` (AddCommand calls) |
+| Flag definitions | `cmd/*.go` (Flags().StringVar, etc.) |
+| Config schema | `internal/model/types.go`, `internal/config/config.go` |
+| Default template | `cmd/config.go` (defaultConfigTemplate) |
+| Example configs | `docs/examples/*.yml` |
+| Root config | `.gh-velocity.yml` |
+| Smoke tests | `scripts/smoke-test.sh`, `scripts/smoke-test-ext.sh` |
+| README | `README.md` |
+| Guide | `docs/guide.md` |
+| Strategy constants | `internal/model/types.go` (StrategyIssue, StrategyPR) |
+| Deprecated flags | `cmd/preflight.go` (MarkDeprecated calls) |
+
+## Sources
+
+- Existing skill pattern: `.claude/skills/github-project-workflow/SKILL.md`
+- Taskfile conventions: `Taskfile.yaml` (sequential cmds, not parallel deps)
+- AGENTS.md conventions: integration tests against built binary, not `go run`
+- Known issues found in v0.0.2 readiness plan: `docs/plans/2026-03-12-005-feat-v002-release-readiness-plan.md`

--- a/scripts/prerelease-analysis.sh
+++ b/scripts/prerelease-analysis.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env bash
+# prerelease-analysis.sh — Tool-agnostic pre-release consistency audit.
+#
+# Checks README, config, smoke tests, and guide against actual code.
+# Returns non-zero if blocking issues are found.
+# Compatible with macOS (BSD grep) and Linux (GNU grep).
+#
+# Usage: bash scripts/prerelease-analysis.sh [--verbose]
+set -euo pipefail
+
+VERBOSE="${1:-}"
+PASS=0
+FAIL=0
+WARN=0
+FINDINGS=""
+
+pass() { PASS=$((PASS + 1)); FINDINGS="${FINDINGS}\n  ✓ $1"; }
+fail() { FAIL=$((FAIL + 1)); FINDINGS="${FINDINGS}\n  ✗ $1"; }
+warn() { WARN=$((WARN + 1)); FINDINGS="${FINDINGS}\n  ⚠ $1"; }
+section() { FINDINGS="${FINDINGS}\n\n$1"; }
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+# Extract registered Cobra commands from cmd/ source files.
+# Builds the full command tree (e.g., "flow lead-time", "config preflight").
+get_registered_commands() {
+    local cmds=()
+
+    # version is added with args
+    if grep -q 'NewVersionCmd' cmd/root.go; then
+        cmds+=("version")
+    fi
+
+    # Sub-commands: parse each group file for AddCommand
+    # flow.go -> flow lead-time, flow cycle-time, flow throughput
+    # quality.go -> quality release
+    # risk.go -> risk bus-factor
+    # status.go -> status wip, status my-week, status reviews
+    # config.go -> config show, config validate, config create, config discover, config preflight
+
+    # get_use_field FILE: extract the Use: "name" field from a Cobra command file
+    get_use_field() {
+        sed -n 's/.*Use:[[:space:]]*"\([^"]*\)".*/\1/p' "$1" | head -1
+    }
+
+    # For each group, find which Go files define the subcommands
+    # by looking up the function name, finding the file, and extracting Use:
+    add_subcommands() {
+        local parent="$1"
+        local group_file="$2"
+        [ -f "$group_file" ] || return
+
+        # Extract function names from AddCommand calls
+        for func in $(sed -n 's/.*cmd\.AddCommand([Nn]ew\([A-Za-z]*\)Cmd().*/\1/p' "$group_file"); do
+            # Find which file defines this function
+            local target_file
+            target_file=$(grep -rl "func [Nn]ew${func}Cmd\b" cmd/*.go 2>/dev/null | head -1)
+            if [ -n "$target_file" ]; then
+                local use_name
+                use_name=$(get_use_field "$target_file")
+                if [ -n "$use_name" ]; then
+                    # Strip any args after space (e.g., "lead-time [issue]" -> "lead-time")
+                    use_name=$(echo "$use_name" | awk '{print $1}')
+                    cmds+=("$parent $use_name")
+                fi
+            fi
+        done
+    }
+
+    add_subcommands "flow" "cmd/flow.go"
+    add_subcommands "quality" "cmd/quality.go"
+    add_subcommands "risk" "cmd/risk.go"
+    add_subcommands "status" "cmd/status.go"
+    add_subcommands "config" "cmd/config.go"
+
+    # report (top-level, leaf)
+    if grep -q 'NewReportCmd' cmd/root.go; then
+        cmds+=("report")
+    fi
+
+    printf '%s\n' "${cmds[@]}" | sort -u
+}
+
+# ── A. README ↔ Code Consistency ──────────────────────────────────────
+
+check_readme() {
+    section "README Consistency"
+
+    if [ ! -f README.md ]; then
+        fail "README.md not found"
+        return
+    fi
+
+    # A1. Command tree: check each registered command appears in README
+    local registered
+    registered=$(get_registered_commands)
+
+    local missing=""
+    while IFS= read -r cmd; do
+        [ -z "$cmd" ] && continue
+        # Check if the command (or its parts) appear in README
+        # For "flow lead-time", check that "lead-time" appears in a flow context
+        local leaf
+        leaf=$(echo "$cmd" | awk '{print $NF}')
+        if ! grep -q "$leaf" README.md; then
+            missing="${missing}${cmd}, "
+        fi
+    done <<< "$registered"
+
+    if [ -n "$missing" ]; then
+        fail "README missing commands: ${missing%, }"
+    else
+        pass "All registered commands mentioned in README"
+    fi
+
+    # A2. Deprecated --project <int> flag without deprecation note
+    if grep -n '\-\-project [0-9]' README.md | grep -v 'deprecated\|project-url' >/dev/null 2>&1; then
+        local lines
+        lines=$(grep -n '\-\-project [0-9]' README.md | grep -v 'deprecated\|project-url' | head -3)
+        fail "README references --project <int> without deprecation note: $lines"
+    else
+        pass "No undocumented deprecated flags"
+    fi
+
+    # A3. Quick Start says "no config needed" but config IS required
+    if grep -i 'no config' README.md | grep -iE 'needed|required|necessary' >/dev/null 2>&1; then
+        fail "README claims no config needed, but config is required for all non-config commands"
+    elif grep -i 'without.*config' README.md >/dev/null 2>&1; then
+        fail "README implies config is optional (found 'without...config')"
+    else
+        pass "Quick Start does not falsely claim config is optional"
+    fi
+
+    # A4. Old field names in config examples
+    if grep -nE 'bug_labels|feature_labels|project\.id[^_]|project: [0-9]' README.md >/dev/null 2>&1; then
+        local lines
+        lines=$(grep -nE 'bug_labels|feature_labels|project\.id[^_]|project: [0-9]' README.md | head -5)
+        fail "README uses deprecated config fields: $lines"
+    else
+        pass "Config fields in README match current schema"
+    fi
+}
+
+# ── B. Config Template ↔ Schema ───────────────────────────────────────
+
+check_configs() {
+    section "Config Consistency"
+
+    # B1. Example configs should parse as valid YAML
+    local example_count=0
+    local example_fail=0
+    for f in docs/examples/*.yml docs/examples/*.yaml; do
+        [ -f "$f" ] || continue
+        example_count=$((example_count + 1))
+        if [ -x ./gh-velocity ]; then
+            if ! ./gh-velocity config validate --config "$f" >/dev/null 2>&1; then
+                fail "Example config fails validation: $f"
+                example_fail=$((example_fail + 1))
+            fi
+        fi
+    done
+
+    if [ "$example_count" -gt 0 ] && [ "$example_fail" -eq 0 ]; then
+        if [ -x ./gh-velocity ]; then
+            pass "All $example_count example configs validate"
+        else
+            warn "Binary not built — skipped example config validation ($example_count configs found)"
+        fi
+    elif [ "$example_count" -eq 0 ]; then
+        warn "No example configs found in docs/examples/"
+    fi
+
+    # B2. Root .gh-velocity.yml validation
+    if [ -f .gh-velocity.yml ] && [ -x ./gh-velocity ]; then
+        local val_output
+        if val_output=$(./gh-velocity config validate 2>&1); then
+            pass "Root .gh-velocity.yml validates"
+        else
+            fail "Root .gh-velocity.yml validation errors: $val_output"
+        fi
+    fi
+
+    # B3. defaultConfigTemplate round-trip
+    if [ -x ./gh-velocity ]; then
+        local tmpdir
+        tmpdir=$(mktemp -d)
+        trap "rm -rf $tmpdir" EXIT
+        if ./gh-velocity config create --config "$tmpdir/.gh-velocity.yml" >/dev/null 2>&1; then
+            if ./gh-velocity config validate --config "$tmpdir/.gh-velocity.yml" >/dev/null 2>&1; then
+                pass "defaultConfigTemplate round-trips through create → validate"
+            else
+                fail "defaultConfigTemplate creates invalid config"
+            fi
+        else
+            warn "config create failed (may need --repo)"
+        fi
+    fi
+}
+
+# ── C. Smoke Test Coverage ────────────────────────────────────────────
+
+check_smoke_tests() {
+    section "Smoke Test Coverage"
+
+    # C1. Check smoke-test-ext.sh for stale command names
+    if [ -f scripts/smoke-test-ext.sh ]; then
+        local stale=""
+
+        # Look for old top-level commands that should now be subcommands
+        # "gh velocity lead-time" should be "gh velocity flow lead-time"
+        if grep -n 'gh velocity lead-time\|gh velocity lead_time' scripts/smoke-test-ext.sh | grep -v 'flow' >/dev/null 2>&1; then
+            local line
+            line=$(grep -n 'gh velocity lead-time\|gh velocity lead_time' scripts/smoke-test-ext.sh | grep -v 'flow' | head -1 | cut -d: -f1)
+            stale="${stale}lead-time (line $line, now: flow lead-time), "
+        fi
+
+        # "gh velocity scope" should be "gh velocity quality release --discover"
+        if grep -n 'gh velocity scope' scripts/smoke-test-ext.sh >/dev/null 2>&1; then
+            local line
+            line=$(grep -n 'gh velocity scope' scripts/smoke-test-ext.sh | head -1 | cut -d: -f1)
+            stale="${stale}scope (line $line, now: quality release --discover), "
+        fi
+
+        # "gh velocity cycle-time" should be "gh velocity flow cycle-time"
+        if grep -n 'gh velocity cycle-time' scripts/smoke-test-ext.sh | grep -v 'flow' >/dev/null 2>&1; then
+            stale="${stale}cycle-time (now: flow cycle-time), "
+        fi
+
+        # "gh velocity throughput" should be "gh velocity flow throughput"
+        if grep -n 'gh velocity throughput' scripts/smoke-test-ext.sh | grep -v 'flow' >/dev/null 2>&1; then
+            stale="${stale}throughput (now: flow throughput), "
+        fi
+
+        # "gh velocity release" as top-level (deprecated, should be "quality release")
+        if grep -n 'gh velocity release' scripts/smoke-test-ext.sh | grep -v 'quality' >/dev/null 2>&1; then
+            local line
+            line=$(grep -n 'gh velocity release' scripts/smoke-test-ext.sh | grep -v 'quality' | head -1 | cut -d: -f1)
+            stale="${stale}release (line $line, now: quality release), "
+        fi
+
+        if [ -n "$stale" ]; then
+            fail "smoke-test-ext.sh uses stale commands: ${stale%, }"
+        else
+            pass "smoke-test-ext.sh uses current command names"
+        fi
+    else
+        warn "scripts/smoke-test-ext.sh not found"
+    fi
+
+    # C2. Command coverage in smoke-test.sh
+    if [ -f scripts/smoke-test.sh ]; then
+        local untested=""
+        local registered
+        registered=$(get_registered_commands)
+
+        while IFS= read -r cmd; do
+            [ -z "$cmd" ] && continue
+            # Skip group parents (they just print help) and deprecated
+            case "$cmd" in
+                flow|quality|risk|status|config|release) continue ;;
+            esac
+
+            # Extract the leaf command name for searching
+            local leaf
+            leaf=$(echo "$cmd" | awk '{print $NF}')
+            if ! grep -q "$leaf" scripts/smoke-test.sh; then
+                untested="${untested}${cmd}, "
+            fi
+        done <<< "$registered"
+
+        if [ -n "$untested" ]; then
+            warn "Commands without smoke test coverage: ${untested%, }"
+        else
+            pass "All leaf commands have smoke test coverage"
+        fi
+    else
+        warn "scripts/smoke-test.sh not found"
+    fi
+}
+
+# ── D. Guide ↔ Code Consistency ───────────────────────────────────────
+
+check_guide() {
+    section "Guide Consistency"
+
+    if [ ! -f docs/guide.md ]; then
+        warn "docs/guide.md not found — skipping guide checks"
+        return
+    fi
+
+    # D1. Strategy names in guide match model constants
+    local guide_strategies
+    guide_strategies=$(sed -n 's/.*strategy:[[:space:]]*\([a-z_-]*\).*/\1/p' docs/guide.md | sort -u || true)
+    if [ -n "$guide_strategies" ]; then
+        local code_strategies
+        # Extract strategy constants: StrategyIssue = "issue", StrategyPR = "pr"
+        code_strategies=$(sed -n 's/.*Strategy[A-Za-z]*[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' internal/model/types.go 2>/dev/null | sort -u || true)
+
+        local bad=""
+        while IFS= read -r s; do
+            [ -z "$s" ] && continue
+            if ! echo "$code_strategies" | grep -qF "$s"; then
+                bad="${bad}${s}, "
+            fi
+        done <<< "$guide_strategies"
+
+        if [ -n "$bad" ]; then
+            fail "Guide references unknown strategies: ${bad%, }"
+        else
+            pass "Strategy names in guide match model constants"
+        fi
+    else
+        pass "No strategy references found in guide (or matches code)"
+    fi
+
+    # D2. Deprecated field names in guide
+    if grep -nE 'bug_labels|feature_labels|project\.id[^_]|project: [0-9]' docs/guide.md >/dev/null 2>&1; then
+        fail "Guide uses deprecated config field names"
+    else
+        pass "Guide config field names are current"
+    fi
+}
+
+# ── E. Release Readiness ──────────────────────────────────────────────
+
+check_release_readiness() {
+    section "Release Readiness"
+
+    # E1. Uncommitted changes
+    if [ -z "$(git status --porcelain 2>/dev/null)" ]; then
+        pass "Working tree clean"
+    else
+        warn "Working tree has uncommitted changes"
+    fi
+
+    # E2. Tests pass
+    if go test ./... -count=1 >/dev/null 2>&1; then
+        pass "All Go tests pass"
+    else
+        fail "Go tests failing"
+    fi
+
+    # E3. Blocking TODOs
+    local blocking
+    blocking=$(grep -rn 'TODO.*release\|FIXME' --include='*.go' . 2>/dev/null | grep -v '_test.go' | grep -v vendor/ || true)
+    if [ -n "$blocking" ]; then
+        local count
+        count=$(echo "$blocking" | wc -l | tr -d ' ')
+        warn "$count TODO/FIXME items in Go source (review before release)"
+    else
+        pass "No blocking TODO/FIXME items"
+    fi
+
+    # E4. goreleaser config check
+    if [ -f .goreleaser.yml ] || [ -f .goreleaser.yaml ]; then
+        if command -v goreleaser >/dev/null 2>&1; then
+            if goreleaser check >/dev/null 2>&1; then
+                pass "goreleaser config valid"
+            else
+                fail "goreleaser check failed"
+            fi
+        else
+            warn "goreleaser not installed — skipped config check"
+        fi
+    fi
+}
+
+# ── Run all checks ────────────────────────────────────────────────────
+
+echo "Pre-Release Analysis"
+echo "===================="
+
+check_readme
+check_configs
+check_smoke_tests
+check_guide
+check_release_readiness
+
+# ── Summary ───────────────────────────────────────────────────────────
+
+echo -e "$FINDINGS"
+echo ""
+echo "Summary: $FAIL blocking, $WARN warnings, $PASS passed"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "Fix $FAIL blocking issue(s) before release."
+    exit 1
+fi
+
+echo ""
+echo "✓ Ready to release"
+exit 0

--- a/scripts/smoke-test-ext.sh
+++ b/scripts/smoke-test-ext.sh
@@ -59,46 +59,45 @@ out=$(gh velocity config validate 2>&1)
 # Clean up config created by config tests (we use --config for remaining tests)
 rm -f .gh-velocity.yml
 
-# ── lead-time ──────────────────────────────────────────────────────
+# ── flow lead-time ─────────────────────────────────────────────────
 echo ""
-echo "lead-time (cli/cli#1)"
+echo "flow lead-time (cli/cli#1)"
 
-out=$(gh velocity lead-time 1 -R cli/cli --config "$CLI_CONFIG" 2>&1)
-[[ "$out" == *"Lead Time"* ]] && pass "lead-time pretty" || fail "lead-time pretty: $out"
+out=$(gh velocity flow lead-time 1 -R cli/cli --config "$CLI_CONFIG" 2>&1)
+[[ "$out" == *"Lead Time"* ]] && pass "flow lead-time pretty" || fail "flow lead-time pretty: $out"
 
-out=$(gh velocity lead-time 1 -R cli/cli --config "$CLI_CONFIG" -f json 2>&1)
-echo "$out" | jq -e '.lead_time_seconds' >/dev/null 2>&1 && pass "lead-time json" || fail "lead-time json: $out"
+out=$(gh velocity flow lead-time 1 -R cli/cli --config "$CLI_CONFIG" -f json 2>&1)
+echo "$out" | jq -e '.lead_time_seconds' >/dev/null 2>&1 && pass "flow lead-time json" || fail "flow lead-time json: $out"
 
-out=$(gh velocity lead-time 1 -R cli/cli --config "$CLI_CONFIG" -f markdown 2>&1)
-[[ "$out" == *"|"* ]] && pass "lead-time markdown" || fail "lead-time markdown: $out"
+out=$(gh velocity flow lead-time 1 -R cli/cli --config "$CLI_CONFIG" -f markdown 2>&1)
+[[ "$out" == *"|"* ]] && pass "flow lead-time markdown" || fail "flow lead-time markdown: $out"
 
-# ── scope ──────────────────────────────────────────────────────────
+# ── quality release --discover ────────────────────────────────────
 echo ""
-echo "scope (cli/cli v2.65.0)"
+echo "quality release --discover (cli/cli v2.65.0)"
 
-out=$(gh velocity scope v2.65.0 -R cli/cli --config "$CLI_CONFIG" --since v2.64.0 2>&1)
-[[ "$out" == *"Scope: v2.65.0"* ]] && pass "scope pretty" || fail "scope pretty: $out"
-[[ "$out" == *"Strategy:"* ]] && pass "scope strategies" || fail "scope strategies: $out"
+out=$(gh velocity quality release v2.65.0 -R cli/cli --config "$CLI_CONFIG" --since v2.64.0 --discover 2>&1)
+[[ "$out" == *"Strategy:"* ]] && pass "quality release --discover strategies" || fail "quality release --discover strategies: $out"
 
-out=$(gh velocity scope v2.65.0 -R cli/cli --config "$CLI_CONFIG" --since v2.64.0 -f json 2>/dev/null)
-echo "$out" | jq -e '.strategies' >/dev/null 2>&1 && pass "scope json" || fail "scope json: $out"
+out=$(gh velocity quality release v2.65.0 -R cli/cli --config "$CLI_CONFIG" --since v2.64.0 --discover -f json 2>/dev/null)
+echo "$out" | jq -e '.strategies' >/dev/null 2>&1 && pass "quality release --discover json" || fail "quality release --discover json: $out"
 
-# ── release ────────────────────────────────────────────────────────
+# ── quality release ───────────────────────────────────────────────
 echo ""
-echo "release (cli/cli v2.65.0)"
+echo "quality release (cli/cli v2.65.0)"
 
-out=$(gh velocity release v2.65.0 -R cli/cli --config "$CLI_CONFIG" --since v2.64.0 2>&1)
-[[ "$out" == *"Release v2.65.0"* ]] && pass "release pretty" || fail "release pretty: $out"
-[[ "$out" == *"Aggregates"* ]] && pass "release aggregates" || fail "release aggregates: $out"
-[[ "$out" == *"P90"* ]] && pass "release has P90" || fail "release missing P90: $out"
+out=$(gh velocity quality release v2.65.0 -R cli/cli --config "$CLI_CONFIG" --since v2.64.0 2>&1)
+[[ "$out" == *"Release v2.65.0"* ]] && pass "quality release pretty" || fail "quality release pretty: $out"
+[[ "$out" == *"Aggregates"* ]] && pass "quality release aggregates" || fail "quality release aggregates: $out"
+[[ "$out" == *"P90"* ]] && pass "quality release has P90" || fail "quality release missing P90: $out"
 
-out=$(gh velocity release v2.65.0 -R cli/cli --config "$CLI_CONFIG" --since v2.64.0 -f json 2>/dev/null)
-echo "$out" | jq -e '.aggregates.lead_time.p90_seconds' >/dev/null 2>&1 && pass "release json p90" || fail "release json p90: $out"
-echo "$out" | jq -e '.aggregates.lead_time.outlier_cutoff_seconds' >/dev/null 2>&1 && pass "release json outlier cutoff" || fail "release json outlier cutoff: $out"
+out=$(gh velocity quality release v2.65.0 -R cli/cli --config "$CLI_CONFIG" --since v2.64.0 -f json 2>/dev/null)
+echo "$out" | jq -e '.aggregates.lead_time.p90_seconds' >/dev/null 2>&1 && pass "quality release json p90" || fail "quality release json p90: $out"
+echo "$out" | jq -e '.aggregates.lead_time.outlier_cutoff_seconds' >/dev/null 2>&1 && pass "quality release json outlier cutoff" || fail "quality release json outlier cutoff: $out"
 
-out=$(gh velocity release v2.65.0 -R cli/cli --config "$CLI_CONFIG" --since v2.64.0 -f markdown 2>/dev/null)
-[[ "$out" == *"## Release v2.65.0"* ]] && pass "release markdown" || fail "release markdown: $out"
-[[ "$out" == *"Outliers"* ]] && pass "release markdown outliers" || fail "release markdown outliers: $out"
+out=$(gh velocity quality release v2.65.0 -R cli/cli --config "$CLI_CONFIG" --since v2.64.0 -f markdown 2>/dev/null)
+[[ "$out" == *"## Release v2.65.0"* ]] && pass "quality release markdown" || fail "quality release markdown: $out"
+[[ "$out" == *"Outliers"* ]] && pass "quality release markdown outliers" || fail "quality release markdown outliers: $out"
 
 # ── my-week ───────────────────────────────────────────────────────
 echo ""
@@ -124,8 +123,8 @@ out=$(gh velocity status my-week -R dvhthomas/gh-velocity --config "${REPO_ROOT}
 echo ""
 echo "error handling"
 
-out=$(gh velocity lead-time abc -R cli/cli --config "$CLI_CONFIG" 2>&1) && fail "bad issue should fail" || pass "bad issue rejected"
-out=$(gh velocity --post lead-time 1 -R cli/cli --config "$CLI_CONFIG" 2>&1) && fail "--post should fail" || pass "--post rejected"
+out=$(gh velocity flow lead-time abc -R cli/cli --config "$CLI_CONFIG" 2>&1) && fail "bad issue should fail" || pass "bad issue rejected"
+out=$(gh velocity --post flow lead-time 1 -R cli/cli --config "$CLI_CONFIG" 2>&1) && fail "--post should fail" || pass "--post rejected"
 
 # ── summary ────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary
- Pre-release analysis skill (`scripts/prerelease-analysis.sh` + `.claude/skills/pre-release-analysis/SKILL.md`) that detects documentation drift, config mismatches, stale tests, and README inaccuracies
- `task release:preflight` Taskfile target for full pre-release validation pipeline
- Fixed all 14 blocking documentation issues found by the analysis: README command tree, deprecated flags, Quick Start config claim, manual config schema, guide command references, CI example portability, smoke test command names

## Changes
- **README.md**: Command tree adds `risk bus-factor`, `status my-week`, `status reviews`; Quick Start now requires config; `--project` → `--project-url`; manual config uses `quality.categories`
- **docs/guide.md**: 30+ bare command refs updated (`release` → `quality release`, etc.); config requirement corrected; `grep -oP` → `grep -oiE`
- **scripts/smoke-test-ext.sh**: `lead-time` → `flow lead-time`, `scope` → `quality release --discover`, `release` → `quality release`
- **scripts/prerelease-analysis.sh**: New tool-agnostic analysis script (macOS/Linux)
- **Taskfile.yaml**: Added `release:preflight` task
- **docs/plans/**: Release readiness and skill plans

## Test plan
- [x] `go test ./...` passes
- [x] `bash scripts/prerelease-analysis.sh` passes (0 blocking, 2 expected warnings)
- [x] `goreleaser check` passes

Closes the documentation gap between v0.0.1 and v0.0.2.