### PR TITLE
feat: showcase JSON + Markdown artifacts with --debug

### DIFF
--- a/.github/workflows/showcase.yaml
+++ b/.github/workflows/showcase.yaml
@@ -28,3 +28,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_VELOCITY_TOKEN }}
         run: scripts/showcase.sh
+
+      - name: Upload showcase artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: showcase-${{ github.run_id }}
+          path: tmp/showcase/
+          retention-days: 30

--- a/scripts/showcase.sh
+++ b/scripts/showcase.sh
@@ -219,6 +219,7 @@ EOF
     # ── 3. Report ───────────────────────────────────────────────
     REPORT=$(run_cmd "report" $BINARY report --since "$SINCE" --config "$CONFIG" -R "$repo" --debug -f markdown)
     if [[ -n "$REPORT" ]]; then
+      echo "$REPORT" > "$TMP_DIR/$slug-report.md"
       {
         echo "### Composite Report"
         echo ""
@@ -235,18 +236,37 @@ EOF
       } >> "$COMMENT_FILE"
     fi
 
+    # Also save JSON report.
+    REPORT_JSON=$(run_cmd "report-json" $BINARY report --since "$SINCE" --config "$CONFIG" -R "$repo" --debug -f json)
+    if [[ -n "$REPORT_JSON" ]]; then
+      echo "$REPORT_JSON" > "$TMP_DIR/$slug-report.json"
+    fi
+
     # ── 4. Individual commands ──────────────────────────────────
     declare -a COMMANDS=(
-      "flow lead-time|Lead Time"
-      "flow cycle-time|Cycle Time"
-      "flow throughput|Throughput"
-      "flow velocity|Velocity"
+      "flow lead-time|Lead Time|lead-time"
+      "flow cycle-time|Cycle Time|cycle-time"
+      "flow throughput|Throughput|throughput"
+      "flow velocity|Velocity|velocity"
     )
 
     for cmd_entry in "${COMMANDS[@]}"; do
-      IFS='|' read -r cmd cmd_label <<< "$cmd_entry"
+      IFS='|' read -r cmd cmd_label cmd_slug <<< "$cmd_entry"
+
+      # Markdown output (for Discussion comment + artifact).
       # shellcheck disable=SC2086
       CMD_OUTPUT=$(run_cmd "$cmd_label" $BINARY $cmd --since "$SINCE" --config "$CONFIG" -R "$repo" --debug -f markdown)
+
+      if [[ -n "$CMD_OUTPUT" ]]; then
+        echo "$CMD_OUTPUT" > "$TMP_DIR/$slug-$cmd_slug.md"
+      fi
+
+      # JSON output (artifact only).
+      # shellcheck disable=SC2086
+      CMD_JSON=$(run_cmd "$cmd_label-json" $BINARY $cmd --since "$SINCE" --config "$CONFIG" -R "$repo" --debug -f json)
+      if [[ -n "$CMD_JSON" ]]; then
+        echo "$CMD_JSON" > "$TMP_DIR/$slug-$cmd_slug.json"
+      fi
 
       {
         echo "<details>"


### PR DESCRIPTION
## Summary

- Save both JSON and Markdown output for every repo/command to `tmp/showcase/` during showcase runs
- Upload `tmp/showcase/` as a workflow artifact (30-day retention, `if: always()` so partial runs still upload)
- All commands already have `--debug` for diagnostic stderr output

Artifact files per repo: `{slug}-report.{md,json}`, `{slug}-{lead-time,cycle-time,throughput,velocity}.{md,json}`

## Test plan

- [ ] Manual workflow dispatch to verify artifact upload
- [ ] Confirm JSON and Markdown files present in downloaded artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)