### PR TITLE
docs: mark shipped plans and brainstorms as completed

### DIFF
--- a/docs/brainstorms/2026-03-14-hugo-documentation-site-brainstorm.md
+++ b/docs/brainstorms/2026-03-14-hugo-documentation-site-brainstorm.md
@@ -1,7 +1,7 @@
 ---
 title: "Hugo Documentation Site for gh-velocity"
 date: 2026-03-14
-status: active
+status: completed
 type: brainstorm
 ---
 

--- a/docs/brainstorms/2026-03-15-daily-velocity-showcase-brainstorm.md
+++ b/docs/brainstorms/2026-03-15-daily-velocity-showcase-brainstorm.md
@@ -1,7 +1,7 @@
 # Daily Velocity Showcase Workflow
 
 **Date:** 2026-03-15
-**Status:** Brainstorm
+**Status:** Completed
 
 ## What We're Building
 

--- a/docs/brainstorms/2026-03-15-documentation-overhaul-brainstorm.md
+++ b/docs/brainstorms/2026-03-15-documentation-overhaul-brainstorm.md
@@ -1,7 +1,7 @@
 # Documentation Overhaul Brainstorm
 
 **Date:** 2026-03-15
-**Status:** Draft
+**Status:** Completed
 
 ## What We're Building
 

--- a/docs/plans/2026-03-12-002-feat-metrics-pipeline-and-ux-plan.md
+++ b/docs/plans/2026-03-12-002-feat-metrics-pipeline-and-ux-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Metrics Pipeline Interface, Config Required, and Empty Messaging"
 type: feat
-status: active
+status: completed
 date: 2026-03-12
 origin: docs/brainstorms/2026-03-12-metric-pipeline-interface-brainstorm.md
 supersedes: docs/plans/2026-03-12-001-feat-metrics-architecture-and-ux-plan.md

--- a/docs/plans/2026-03-12-004-fix-first-run-experience-and-strategy-completeness-plan.md
+++ b/docs/plans/2026-03-12-004-fix-first-run-experience-and-strategy-completeness-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Fix First-Run Experience and Strategy Completeness"
 type: fix
-status: active
+status: completed
 date: 2026-03-12
 origin: docs/brainstorms/2026-03-12-strategy-completeness-audit-brainstorm.md
 ---

--- a/docs/plans/2026-03-12-005-feat-v002-release-readiness-plan.md
+++ b/docs/plans/2026-03-12-005-feat-v002-release-readiness-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "v0.0.2 Release Readiness"
 type: feat
-status: active
+status: completed
 date: 2026-03-12
 ---
 

--- a/docs/plans/2026-03-12-006-feat-prerelease-analysis-skill-and-release-task-plan.md
+++ b/docs/plans/2026-03-12-006-feat-prerelease-analysis-skill-and-release-task-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Pre-Release Analysis Skill and Release Task"
 type: feat
-status: active
+status: abandoned
 date: 2026-03-12
 ---
 

--- a/docs/plans/2026-03-14-002-feat-hugo-documentation-site-plan.md
+++ b/docs/plans/2026-03-14-002-feat-hugo-documentation-site-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Hugo documentation site"
 type: feat
-status: active
+status: completed
 date: 2026-03-14
 origin: docs/brainstorms/2026-03-14-hugo-documentation-site-brainstorm.md
 ---

--- a/docs/plans/2026-03-15-001-feat-daily-velocity-showcase-workflow-plan.md
+++ b/docs/plans/2026-03-15-001-feat-daily-velocity-showcase-workflow-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Daily velocity showcase workflow"
 type: feat
-status: active
+status: completed
 date: 2026-03-15
 origin: docs/brainstorms/2026-03-15-daily-velocity-showcase-brainstorm.md
 ---

--- a/docs/plans/2026-03-15-002-feat-disk-cache-and-n-plus-one-fix-plan.md
+++ b/docs/plans/2026-03-15-002-feat-disk-cache-and-n-plus-one-fix-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Disk cache and N+1 project status fix"
 type: feat
-status: active
+status: completed
 date: 2026-03-15
 origin: docs/brainstorms/2026-03-15-showcase-improvements-roadmap-brainstorm.md
 ---


### PR DESCRIPTION
## Summary
- Mark 8 shipped plans/brainstorms as completed (metrics pipeline, first-run experience, v0.0.2, hugo docs, daily showcase, disk cache, documentation overhaul)
- Mark pre-release analysis skill plan as abandoned
- Created tracking issues for remaining active plans: #85, #86
- Created verification issue #84 for first-run experience cross-cutting checks