### PR TITLE
fix: explain outlier threshold origin in insight messages

### DIFF
--- a/internal/metrics/report_insights.go
+++ b/internal/metrics/report_insights.go
@@ -49,7 +49,7 @@ func GenerateStatsInsights(stats model.Stats, section string, items []ItemRef) [
 	if stats.OutlierCount >= OutlierMinCount && stats.OutlierCutoff != nil {
 		insights = append(insights, model.Insight{
 			Type:    "outlier_detection",
-			Message: fmt.Sprintf("%d outliers above %s threshold — consider investigating long-lived items.", stats.OutlierCount, fmtDur(*stats.OutlierCutoff)),
+			Message: fmt.Sprintf("%d outliers above the %s IQR threshold (Q3 + 1.5×IQR) — consider investigating long-lived items.", stats.OutlierCount, fmtDur(*stats.OutlierCutoff)),
 		})
 	}
 


### PR DESCRIPTION
## Summary
- Outlier detection insight now says "above the 56d 14h IQR threshold (Q3 + 1.5×IQR)" instead of just "above 56d 14h threshold"
- Readers immediately understand the number comes from the interquartile range calculation, not an arbitrary cutoff

## Testing
- Existing tests pass (use substring matching, not exact message comparison)

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: cosmetic change to insight message text only.

Closes dvhthomas/gh-velocity#82