### PR TITLE
fix: move summary above detail table, drop IQR jargon

### DIFF
--- a/internal/metrics/report_insights.go
+++ b/internal/metrics/report_insights.go
@@ -49,7 +49,7 @@ func GenerateStatsInsights(stats model.Stats, section string, items []ItemRef) [
 	if stats.OutlierCount >= OutlierMinCount && stats.OutlierCutoff != nil {
 		insights = append(insights, model.Insight{
 			Type:    "outlier_detection",
-			Message: fmt.Sprintf("%d outliers above the %s IQR threshold (Q3 + 1.5×IQR) — consider investigating long-lived items.", stats.OutlierCount, fmtDur(*stats.OutlierCutoff)),
+			Message: fmt.Sprintf("%d outliers above %s (statistical outlier threshold) — consider investigating long-lived items.", stats.OutlierCount, fmtDur(*stats.OutlierCutoff)),
 		})
 	}
 

--- a/internal/pipeline/cycletime/render.go
+++ b/internal/pipeline/cycletime/render.go
@@ -254,6 +254,7 @@ func WriteBulkPretty(rc format.RenderContext, repo string, since, until time.Tim
 	fmt.Fprintf(rc.Writer, "Cycle Time: %s (%s – %s UTC) [%s]\n\n",
 		repo, since.UTC().Format(time.DateOnly), until.UTC().Format(time.DateOnly), strategy)
 	model.WriteInsightsPretty(rc.Writer, insights)
+	fmt.Fprintf(rc.Writer, "  Summary: %s\n\n", format.FormatStatsSummary(stats))
 
 	if len(sorted) == 0 {
 		fmt.Fprintln(rc.Writer, "  No issues closed in this period.")
@@ -282,12 +283,7 @@ func WriteBulkPretty(rc format.RenderContext, repo string, since, until time.Tim
 		tp.AddField(format.FormatMetricDuration(item.Metric))
 		tp.EndRow()
 	}
-	if err := tp.Render(); err != nil {
-		return err
-	}
-
-	fmt.Fprintf(rc.Writer, "\n%s\n", format.FormatStatsSummary(stats))
-	return nil
+	return tp.Render()
 }
 
 // --- Helpers ---

--- a/internal/pipeline/cycletime/templates/cycletime-bulk.md.tmpl
+++ b/internal/pipeline/cycletime/templates/cycletime-bulk.md.tmpl
@@ -6,14 +6,19 @@
 - {{.}}
 {{- end}}
 {{- end}}
+
+**Summary:** {{.Summary}}
 {{if .Items}}
+<details>
+<summary>Details ({{len .Items}} issues)</summary>
+
 | Issue | Title | Labels | Started (UTC) | Closed (UTC) | Cycle Time |
 | ---: | --- | --- | --- | --- | --- |
 {{- range .Items}}
 | {{.Link}} | {{.Title}} | {{.Labels}} | {{.Started}} | {{.Closed}} | {{.CycleTime}} |
 {{- end}}
 
-**Summary:** {{.Summary}}
+</details>
 {{- else}}
 _No issues closed in this period._
 {{- if .SearchURL}}

--- a/internal/pipeline/leadtime/render.go
+++ b/internal/pipeline/leadtime/render.go
@@ -181,6 +181,7 @@ func WriteBulkPretty(rc format.RenderContext, repo string, since, until time.Tim
 	fmt.Fprintf(rc.Writer, "Lead Time: %s (%s – %s UTC)\n\n",
 		repo, since.UTC().Format(time.DateOnly), until.UTC().Format(time.DateOnly))
 	model.WriteInsightsPretty(rc.Writer, insights)
+	fmt.Fprintf(rc.Writer, "  Summary: %s\n\n", format.FormatStatsSummary(stats))
 
 	if len(sorted) == 0 {
 		fmt.Fprintln(rc.Writer, "  No issues closed in this period.")
@@ -205,12 +206,7 @@ func WriteBulkPretty(rc format.RenderContext, repo string, since, until time.Tim
 		tp.AddField(format.FormatMetricDuration(item.Metric))
 		tp.EndRow()
 	}
-	if err := tp.Render(); err != nil {
-		return err
-	}
-
-	fmt.Fprintf(rc.Writer, "\n%s\n", format.FormatStatsSummary(stats))
-	return nil
+	return tp.Render()
 }
 
 // --- Helpers ---

--- a/internal/pipeline/leadtime/templates/leadtime-bulk.md.tmpl
+++ b/internal/pipeline/leadtime/templates/leadtime-bulk.md.tmpl
@@ -6,14 +6,19 @@
 - {{.}}
 {{- end}}
 {{- end}}
+
+**Summary:** {{.Summary}}
 {{if .Items}}
+<details>
+<summary>Details ({{len .Items}} issues)</summary>
+
 | Issue | Title | Labels | Created (UTC) | Closed (UTC) | Lead Time |
 | ---: | --- | --- | --- | --- | --- |
 {{- range .Items}}
 | {{.Link}} | {{.Title}} | {{.Labels}} | {{.Created}} | {{.Closed}} | {{.LeadTime}} |
 {{- end}}
 
-**Summary:** {{.Summary}}
+</details>
 {{- else}}
 _No issues closed in this period._
 {{- if .SearchURL}}


### PR DESCRIPTION
## Summary
- Detail sections now show: heading → insights → summary → collapsible per-item table
- Previously summary stats were buried below a long table of issues
- Outlier insight message now says "statistical outlier threshold" instead of "IQR threshold (Q3 + 1.5×IQR)"

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: layout and message text changes only.