### PR TITLE
feat(stats): CV/predictability, humanized outlier insights

### DIFF
--- a/internal/format/json.go
+++ b/internal/format/json.go
@@ -51,8 +51,12 @@ type JSONStats struct {
 	StdDevSeconds        *int64        `json:"stddev_seconds,omitempty"`
 	P90Seconds           *int64        `json:"p90_seconds,omitempty"`
 	P95Seconds           *int64        `json:"p95_seconds,omitempty"`
+	Q1Seconds            *int64        `json:"q1_seconds,omitempty"`
+	Q3Seconds            *int64        `json:"q3_seconds,omitempty"`
 	OutlierCutoffSeconds *int64        `json:"outlier_cutoff_seconds,omitempty"`
 	OutlierCount         int           `json:"outlier_count,omitempty"`
+	CV                   *float64      `json:"cv,omitempty"`
+	Predictability       string        `json:"predictability,omitempty"`
 	Insights             []jsonInsight `json:"insights,omitempty"`
 }
 
@@ -67,6 +71,7 @@ func DurationToSeconds(d *time.Duration) *int64 {
 
 // StatsToJSON converts model.Stats to its JSON representation.
 func StatsToJSON(s model.Stats) JSONStats {
+	cv := ComputeCV(s)
 	return JSONStats{
 		Count:                s.Count,
 		MeanSeconds:          DurationToSeconds(s.Mean),
@@ -74,7 +79,11 @@ func StatsToJSON(s model.Stats) JSONStats {
 		StdDevSeconds:        DurationToSeconds(s.StdDev),
 		P90Seconds:           DurationToSeconds(s.P90),
 		P95Seconds:           DurationToSeconds(s.P95),
+		Q1Seconds:            DurationToSeconds(s.Q1),
+		Q3Seconds:            DurationToSeconds(s.Q3),
 		OutlierCutoffSeconds: DurationToSeconds(s.OutlierCutoff),
 		OutlierCount:         s.OutlierCount,
+		CV:                   cv,
+		Predictability:       PredictabilityLabel(cv),
 	}
 }

--- a/internal/format/markdown.go
+++ b/internal/format/markdown.go
@@ -12,6 +12,11 @@ const maxTitleLength = 200
 // htmlPolicy strips all HTML tags from content.
 var htmlPolicy = bluemonday.StrictPolicy()
 
+// StripMarkdownBold removes **bold** markers from a string for plain-text output.
+func StripMarkdownBold(s string) string {
+	return strings.ReplaceAll(s, "**", "")
+}
+
 // SanitizeMarkdown sanitizes third-party text for safe insertion into markdown tables.
 // It strips HTML tags, escapes markdown-breaking characters, removes newlines,
 // and truncates to maxTitleLength.

--- a/internal/format/report.go
+++ b/internal/format/report.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"time"
 
 	"github.com/bitsbyme/gh-velocity/internal/model"
@@ -166,6 +167,7 @@ func WriteReportPretty(rc RenderContext, r model.StatsResult) error {
 	if r.CycleTime != nil {
 		fmt.Fprintf(w, "  Cycle Time:  %s\n", FormatStatsSummary(*r.CycleTime))
 	} else if r.CycleTimeStrategy != "" {
+
 		switch r.CycleTimeStrategy {
 		case model.StrategyIssue:
 			fmt.Fprintf(w, "  Cycle Time:  not available (configure lifecycle.in-progress with project_status or match)\n")
@@ -236,7 +238,8 @@ func buildInsightGroups(r model.StatsResult) []insightGroup {
 	return groups
 }
 
-// FormatStatsSummary returns a compact stats summary like "median 3.2d, mean 5.1d, P90 8.1d (n=14, 2 outliers)".
+// FormatStatsSummary returns a compact one-line stats summary for table cells:
+// "median 43d 20h, P90 446d 20h, predictability: low (n=21)".
 func FormatStatsSummary(s model.Stats) string {
 	if s.Count == 0 {
 		return "no data"
@@ -245,22 +248,74 @@ func FormatStatsSummary(s model.Stats) string {
 	if s.Median != nil {
 		result += fmt.Sprintf("median %s", FormatDuration(*s.Median))
 	}
-	if s.Mean != nil {
-		if result != "" {
-			result += ", "
-		}
-		result += fmt.Sprintf("mean %s", FormatDuration(*s.Mean))
-	}
 	if s.P90 != nil {
 		if result != "" {
 			result += ", "
 		}
 		result += fmt.Sprintf("P90 %s", FormatDuration(*s.P90))
 	}
-	suffix := fmt.Sprintf("n=%d", s.Count)
-	if s.OutlierCount > 0 {
-		suffix += fmt.Sprintf(", %d outliers", s.OutlierCount)
+	if label := PredictabilityLabel(ComputeCV(s)); label != "" {
+		if result != "" {
+			result += ", "
+		}
+		result += fmt.Sprintf("predictability: %s", label)
 	}
-	result += fmt.Sprintf(" (%s)", suffix)
+	result += fmt.Sprintf(" (n=%d)", s.Count)
 	return result
+}
+
+// FormatStatsDetail returns a bullet list of stats for detail sections.
+// Each entry is a line like "**Median:** 43d 20h". Suitable for markdown
+// (with "- " prefix) or pretty-text (with aligned labels).
+func FormatStatsDetail(s model.Stats) []string {
+	if s.Count == 0 {
+		return []string{"No data"}
+	}
+	var lines []string
+	if s.Median != nil {
+		lines = append(lines, fmt.Sprintf("**Median:** %s", FormatDuration(*s.Median)))
+	}
+	if s.Mean != nil {
+		lines = append(lines, fmt.Sprintf("**Mean:** %s", FormatDuration(*s.Mean)))
+	}
+	if s.P90 != nil {
+		lines = append(lines, fmt.Sprintf("**P90:** %s", FormatDuration(*s.P90)))
+	}
+	cv := ComputeCV(s)
+	if label := PredictabilityLabel(cv); label != "" {
+		lines = append(lines, fmt.Sprintf("**Predictability:** %s (CV %.1f)", label, *cv))
+	}
+	sampleSize := fmt.Sprintf("%d", s.Count)
+	if s.OutlierCount > 0 {
+		sampleSize += fmt.Sprintf(" (%d outliers)", s.OutlierCount)
+	}
+	lines = append(lines, fmt.Sprintf("**Sample size:** %s", sampleSize))
+	return lines
+}
+
+// ComputeCV returns the coefficient of variation (stddev/mean) for stats,
+// or nil if insufficient data.
+func ComputeCV(s model.Stats) *float64 {
+	if s.StdDev == nil || s.Mean == nil || *s.Mean == 0 {
+		return nil
+	}
+	cv := float64(*s.StdDev) / float64(*s.Mean)
+	cv = math.Round(cv*10) / 10 // one decimal place
+	return &cv
+}
+
+// PredictabilityLabel returns a human-readable predictability label based on CV.
+// Returns "" for high predictability (CV < 0.5) or nil CV.
+func PredictabilityLabel(cv *float64) string {
+	if cv == nil {
+		return ""
+	}
+	switch {
+	case *cv > 1.0:
+		return "low"
+	case *cv >= 0.5:
+		return "moderate"
+	default:
+		return ""
+	}
 }

--- a/internal/metrics/report_insights.go
+++ b/internal/metrics/report_insights.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+	"math"
 	"slices"
 	"sort"
 	"strings"
@@ -45,14 +46,36 @@ func GenerateStatsInsights(stats model.Stats, section string, items []ItemRef) [
 		return nil
 	}
 
-	// Outlier detection.
-	if stats.OutlierCount >= OutlierMinCount && stats.OutlierCutoff != nil {
+	// Outlier detection — express in terms of median multiples, not IQR jargon.
+	if stats.OutlierCount >= OutlierMinCount && stats.OutlierCutoff != nil && stats.Median != nil && *stats.Median > 0 {
+		multiple := int(math.Round(float64(*stats.OutlierCutoff) / float64(*stats.Median)))
+		if multiple < 2 {
+			multiple = 2
+		}
 		insights = append(insights, model.Insight{
 			Type: "outlier_detection",
 			Message: fmt.Sprintf(
-				"%d outliers above %s — the IQR outlier threshold, meaning these items took significantly longer than the middle 50%% of the data.",
-				stats.OutlierCount, fmtDur(*stats.OutlierCutoff)),
+				"%d items took %dx longer than the median (%s).",
+				stats.OutlierCount, multiple, fmtDur(*stats.Median)),
 		})
+	}
+
+	// Predictability — surface CV when delivery times vary notably.
+	if stats.StdDev != nil && stats.Mean != nil && *stats.Mean > 0 {
+		cv := float64(*stats.StdDev) / float64(*stats.Mean)
+		cv = math.Round(cv*10) / 10
+		switch {
+		case cv > 1.0:
+			insights = append(insights, model.Insight{
+				Type:    "predictability",
+				Message: fmt.Sprintf("Delivery times vary widely (CV %.1f) — the median is a more reliable estimate than the mean.", cv),
+			})
+		case cv >= 0.5:
+			insights = append(insights, model.Insight{
+				Type:    "predictability",
+				Message: fmt.Sprintf("Moderate delivery time variability (CV %.1f) — some items take significantly longer than others.", cv),
+			})
+		}
 	}
 
 	// Skew warning.

--- a/internal/metrics/report_insights_test.go
+++ b/internal/metrics/report_insights_test.go
@@ -79,7 +79,7 @@ func TestGenerateStatsInsights(t *testing.T) {
 			wantCount: 0,
 		},
 		{
-			name: "outliers at threshold fires",
+			name: "outliers at threshold fires with median multiple",
 			stats: model.Stats{
 				Count:         10,
 				OutlierCount:  2,
@@ -88,7 +88,7 @@ func TestGenerateStatsInsights(t *testing.T) {
 				Median:        ptrDur(dur(5)),
 			},
 			wantCount:  1,
-			wantSubstr: "2 outliers",
+			wantSubstr: "2 items took",
 			wantType:   "outlier_detection",
 		},
 		{
@@ -192,6 +192,40 @@ func TestGenerateStatsInsights(t *testing.T) {
 			},
 			wantCount: 4, // outlier + skew + fastest/slowest + category
 		},
+		{
+			name: "predictability low fires when CV > 1.0",
+			stats: model.Stats{
+				Count:  10,
+				Mean:   ptrDur(dur(10)),
+				Median: ptrDur(dur(5)),
+				StdDev: ptrDur(dur(15)), // CV = 15/10 = 1.5
+			},
+			wantCount:  1,
+			wantSubstr: "vary widely",
+			wantType:   "predictability",
+		},
+		{
+			name: "predictability moderate fires when CV 0.5-1.0",
+			stats: model.Stats{
+				Count:  10,
+				Mean:   ptrDur(dur(10)),
+				Median: ptrDur(dur(8)),
+				StdDev: ptrDur(dur(7)), // CV = 7/10 = 0.7
+			},
+			wantCount:  1,
+			wantSubstr: "Moderate delivery",
+			wantType:   "predictability",
+		},
+		{
+			name: "predictability silent when CV < 0.5",
+			stats: model.Stats{
+				Count:  10,
+				Mean:   ptrDur(dur(10)),
+				Median: ptrDur(dur(9)),
+				StdDev: ptrDur(dur(3)), // CV = 3/10 = 0.3
+			},
+			wantCount: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -258,7 +292,7 @@ func TestGenerateCycleTimeInsights(t *testing.T) {
 			},
 			strategy:   model.StrategyIssue,
 			wantCount:  2, // outlier + skew
-			wantSubstr: "outlier",
+			wantSubstr: "3 items took",
 		},
 	}
 

--- a/internal/metrics/stats.go
+++ b/internal/metrics/stats.go
@@ -84,6 +84,8 @@ func ComputeStats(durations []time.Duration) model.Stats {
 	if n >= 4 {
 		q1 := percentile(sorted, 25)
 		q3 := percentile(sorted, 75)
+		stats.Q1 = &q1
+		stats.Q3 = &q3
 		iqr := q3 - q1
 		cutoff := q3 + time.Duration(float64(iqr)*1.5)
 		stats.OutlierCutoff = &cutoff

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -161,6 +161,8 @@ type Stats struct {
 	StdDev        *time.Duration // sample standard deviation; nil if N < 2
 	P90           *time.Duration // 90th percentile; nil if N < 2
 	P95           *time.Duration // 95th percentile; nil if N < 2
+	Q1            *time.Duration // 25th percentile; nil if N < 4
+	Q3            *time.Duration // 75th percentile; nil if N < 4
 	OutlierCutoff *time.Duration // Q3 + 1.5*IQR; values above are outliers
 	OutlierCount  int            // number of values above the cutoff
 	NegativeCount int            // durations < 0 filtered before computation

--- a/internal/pipeline/cycletime/render.go
+++ b/internal/pipeline/cycletime/render.go
@@ -193,6 +193,7 @@ type bulkTemplateData struct {
 	Strategy   string
 	Insights   []string
 	Items      []bulkItemRow
+	Detail     []string
 	Summary    string
 	SearchURL  string
 }
@@ -219,6 +220,7 @@ func WriteBulkMarkdown(rc format.RenderContext, repo string, since, until time.T
 		Until:      until,
 		Strategy:   strategy,
 		Insights:   insightMsgs,
+		Detail:     format.FormatStatsDetail(stats),
 		Summary:    format.FormatStatsSummary(stats),
 		SearchURL:  searchURL,
 	}
@@ -254,7 +256,11 @@ func WriteBulkPretty(rc format.RenderContext, repo string, since, until time.Tim
 	fmt.Fprintf(rc.Writer, "Cycle Time: %s (%s – %s UTC) [%s]\n\n",
 		repo, since.UTC().Format(time.DateOnly), until.UTC().Format(time.DateOnly), strategy)
 	model.WriteInsightsPretty(rc.Writer, insights)
-	fmt.Fprintf(rc.Writer, "  Summary: %s\n\n", format.FormatStatsSummary(stats))
+	fmt.Fprintln(rc.Writer, "  Summary:")
+	for _, line := range format.FormatStatsDetail(stats) {
+		fmt.Fprintf(rc.Writer, "    %s\n", format.StripMarkdownBold(line))
+	}
+	fmt.Fprintln(rc.Writer)
 
 	if len(sorted) == 0 {
 		fmt.Fprintln(rc.Writer, "  No issues closed in this period.")

--- a/internal/pipeline/cycletime/templates/cycletime-bulk.md.tmpl
+++ b/internal/pipeline/cycletime/templates/cycletime-bulk.md.tmpl
@@ -7,7 +7,10 @@
 {{- end}}
 {{- end}}
 
-**Summary:** {{.Summary}}
+**Summary:**
+{{- range .Detail}}
+- {{.}}
+{{- end}}
 {{if .Items}}
 <details>
 <summary>Details ({{len .Items}} issues)</summary>

--- a/internal/pipeline/leadtime/render.go
+++ b/internal/pipeline/leadtime/render.go
@@ -125,6 +125,7 @@ type bulkTemplateData struct {
 	Until      time.Time
 	Insights   []string
 	Items      []bulkItemRow
+	Detail     []string
 	Summary    string
 	SearchURL  string
 }
@@ -150,6 +151,7 @@ func WriteBulkMarkdown(rc format.RenderContext, repo string, since, until time.T
 		Since:      since,
 		Until:      until,
 		Insights:   insightMsgs,
+		Detail:     format.FormatStatsDetail(stats),
 		Summary:    format.FormatStatsSummary(stats),
 		SearchURL:  searchURL,
 	}
@@ -181,7 +183,11 @@ func WriteBulkPretty(rc format.RenderContext, repo string, since, until time.Tim
 	fmt.Fprintf(rc.Writer, "Lead Time: %s (%s – %s UTC)\n\n",
 		repo, since.UTC().Format(time.DateOnly), until.UTC().Format(time.DateOnly))
 	model.WriteInsightsPretty(rc.Writer, insights)
-	fmt.Fprintf(rc.Writer, "  Summary: %s\n\n", format.FormatStatsSummary(stats))
+	fmt.Fprintln(rc.Writer, "  Summary:")
+	for _, line := range format.FormatStatsDetail(stats) {
+		fmt.Fprintf(rc.Writer, "    %s\n", format.StripMarkdownBold(line))
+	}
+	fmt.Fprintln(rc.Writer)
 
 	if len(sorted) == 0 {
 		fmt.Fprintln(rc.Writer, "  No issues closed in this period.")

--- a/internal/pipeline/leadtime/templates/leadtime-bulk.md.tmpl
+++ b/internal/pipeline/leadtime/templates/leadtime-bulk.md.tmpl
@@ -7,7 +7,10 @@
 {{- end}}
 {{- end}}
 
-**Summary:** {{.Summary}}
+**Summary:**
+{{- range .Detail}}
+- {{.}}
+{{- end}}
 {{if .Items}}
 <details>
 <summary>Details ({{len .Items}} issues)</summary>

--- a/site/content/concepts/statistics.md
+++ b/site/content/concepts/statistics.md
@@ -48,19 +48,97 @@ In practice: if most issues in a release close in 5-15 days, an issue that took 
 
 Outlier detection requires at least 4 data points. Flagged issues appear with `OUTLIER` in pretty and markdown output, and `lead_time_outlier: true` in JSON output.
 
-## Standard deviation
+## Standard deviation and predictability (CV)
 
-Standard deviation measures how spread out your durations are. The tool uses sample standard deviation (N-1 denominator).
+Standard deviation measures how spread out your durations are. Think of it as "on average, how far is each item from the mean?" A small standard deviation means items cluster tightly; a large one means they are all over the map. The tool uses sample standard deviation (divides by N-1, not N).
 
-The raw number is hard to interpret on its own. The useful signal is the ratio of standard deviation to mean:
+But the raw standard deviation is hard to interpret on its own. If someone tells you "the standard deviation of our lead times is 20 days," your follow-up question should be "20 days compared to what?" A 20-day spread when your mean is 5 days is chaotic. A 20-day spread when your mean is 200 days is rock-solid.
 
-- **stddev / mean < 0.5**: Your delivery times are fairly consistent.
-- **stddev / mean near 1.0**: Significant variability. Some issues take much longer than others.
-- **stddev / mean > 1.0**: Highly variable. Predicting delivery time for any single issue is unreliable.
+### Coefficient of variation (CV)
 
-High variability is not inherently bad -- it often reflects a mix of quick fixes and longer projects. But if you are trying to make delivery more predictable, reducing this ratio is a concrete goal.
+The **coefficient of variation** answers "compared to what?" by dividing:
 
-Standard deviation requires at least 2 data points.
+```
+CV = standard deviation / mean
+```
+
+The result is a dimensionless ratio. A CV of 0.3 means the standard deviation is 30% of the mean. A CV of 2.0 means the standard deviation is twice the mean.
+
+**Why CV instead of raw standard deviation?** Issue durations naturally span a huge range. A backlog might contain a 20-minute typo fix and a 3-month platform migration, and both close in the same sprint. Standard deviation alone cannot tell you whether the spread in your data is "a lot" or "normal for the scale." CV normalizes the spread so you can compare across time windows, across teams, and across repositories -- even when the absolute durations are very different.
+
+An analogy: imagine two pizza delivery services. Service A delivers in 25-35 minutes (mean 30, stddev 5, CV 0.17). Service B delivers in 10-60 minutes (mean 30, stddev 18, CV 0.60). Both have the same mean, but Service B is far less predictable. CV captures this; raw standard deviation alone might mislead you if the means differed.
+
+### How to read the predictability label
+
+gh-velocity translates CV into a plain-language **predictability** label so you do not have to remember thresholds:
+
+| CV | Label | What it tells you |
+|----|-------|-------------------|
+| < 0.5 | _(not shown)_ | Delivery times are consistent. If someone asks "how long will this take?" the median is a solid answer. |
+| 0.5 -- 1.0 | **moderate** | Noticeable variation. Most items land near the median, but some take 2-3x longer. Worth investigating the slow ones. |
+| > 1.0 | **low** | The spread exceeds the average itself. Predicting any single item's duration is unreliable. The median is a better anchor than the mean, but expect surprises. |
+
+### When is high variability OK?
+
+High variability is not automatically bad. Consider two scenarios:
+
+1. **Mixed-size backlog** (bugs + features + epics): A team closing 1-hour hotfixes and 3-week features in the same window will naturally have a high CV. This is expected. The insight to take away is: "don't quote the mean as a delivery estimate."
+
+2. **Uniform sprint work** (all items are roughly story-point sized): If you expect items to take 2-5 days each, a CV of 1.5 means something is off. Some items are ballooning. The insight to take away is: "investigate the slow outliers."
+
+The predictability label helps you spot the second scenario without doing arithmetic.
+
+### Worked example
+
+From a real repository (the astral-sh/uv report above):
+
+| Measure | Value |
+|---------|-------|
+| Mean lead time | 5h 56m |
+| Median lead time | 2h 35m |
+| Standard deviation | 8h 33m |
+| CV | 1.4 |
+| Predictability | low |
+
+The CV of 1.4 means the spread is 1.4 times the mean. In plain terms: the "typical" issue takes about 2.5 hours (median), but the variation is so large that some items take 10x longer. The tool surfaces this as:
+
+> Delivery times vary widely (CV 1.4) -- the median is a more reliable estimate than the mean.
+
+If you looked only at the mean (6 hours), you might set expectations that most items take half a day. The median (2.5 hours) is closer to what people actually experience. The CV tells you the mean is distorted.
+
+### A more extreme example
+
+From cli/cli v2.67.0:
+
+| Measure | Value |
+|---------|-------|
+| Mean lead time | 280 days |
+| Median lead time | 60 days |
+| Standard deviation | ~1,300 days |
+| CV | ~4.6 |
+| Predictability | low |
+
+A CV of 4.6 means the standard deviation is nearly five times the mean. Two issues that had been open for 4+ years were closed alongside recent work. The mean (280 days) is wildly misleading. The median (60 days) is the number to quote. The predictability label "low" tells you this at a glance.
+
+### CV in JSON output
+
+JSON output includes both the raw CV value and the label:
+
+```json
+{
+  "cv": 1.4,
+  "predictability": "low"
+}
+```
+
+You can use these in scripts or dashboards. For example, to alert when predictability drops:
+
+```bash
+gh velocity flow lead-time --since 30d --format json | \
+  jq -r 'if .stats.cv > 1.0 then "WARNING: low predictability (CV \(.stats.cv))" else "OK" end'
+```
+
+Standard deviation and CV require at least 2 data points.
 
 ## See also
 

--- a/site/content/guides/interpreting-results.md
+++ b/site/content/guides/interpreting-results.md
@@ -130,7 +130,7 @@ There are no universal benchmarks. What matters is your trend over time and whet
 
 - **Median under 30 days** for most product teams. This means a typical issue goes from creation to close within a month.
 - **P95 under 90 days**. If your P95 is over 90 days, old issues are being closed alongside new work, which is normal but worth understanding.
-- **Low stddev relative to the mean**. If `stddev / mean > 1`, delivery times are highly variable. Consistent teams have lower relative standard deviation.
+- **Predictability label is not "low"**. The predictability label is derived from the coefficient of variation (CV = stddev / mean). A "low" label means individual item durations are hard to predict. See [Understanding Statistics]({{< relref "/concepts/statistics#standard-deviation-and-predictability-cv" >}}) for details.
 
 ### [Cycle time]({{< relref "/reference/metrics/cycle-time" >}})
 


### PR DESCRIPTION
## Summary
- Reworked stats summary: compact line (median, P90, predictability label) for tables, bullet list (median, mean, P90, CV, sample size) for detail sections
- Outlier insights now say "N items took Mx longer than the median" instead of IQR jargon
- New predictability insight fires when CV >= 0.5 with actionable guidance
- JSON output includes `cv` and `predictability` fields
- Docs: thorough CV explanation with pizza delivery analogy, worked examples, and JSON usage

## Test plan
- [x] `go test ./... -count=1` — all 22 packages pass
- [x] `./gh-velocity report --since 90d -R astral-sh/uv --format markdown` — verified bullet list, compact table row, humanized insights
- [x] `./gh-velocity report --since 90d -R astral-sh/uv --format json` — verified cv/predictability fields present
- [ ] Run showcase workflow after merge to validate against multiple real repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)