### PR TITLE
fix: avoid live owner mentions in markdown reports

### DIFF
--- a/internal/format/wip_detail.go
+++ b/internal/format/wip_detail.go
@@ -538,17 +538,15 @@ func WriteWIPDetailPretty(rc RenderContext, result model.WIPResult) error {
 	return nil
 }
 
-// formatOwnerMarkdown returns a GitHub @handle for markdown output.
-// GitHub's renderer auto-links @mentions, so no explicit URL needed.
+// formatOwnerMarkdown renders an owner handle for markdown output without
+// triggering a live GitHub @mention notification.
 // "unassigned" is returned as-is (not a GitHub handle).
 func formatOwnerMarkdown(login string) string {
 	if login == "unassigned" {
 		return login
 	}
-	if strings.HasPrefix(login, "@") {
-		return login
-	}
-	return "@" + login
+	login = strings.TrimPrefix(login, "@")
+	return "`@" + login + "`"
 }
 
 // countByKind counts issues and PRs in the item list.

--- a/internal/format/wip_detail_test.go
+++ b/internal/format/wip_detail_test.go
@@ -1,0 +1,25 @@
+package format
+
+import "testing"
+
+func TestFormatOwnerMarkdown(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "plain login", input: "liruiluo", want: "`@liruiluo`"},
+		{name: "prefixed login", input: "@zanieb", want: "`@zanieb`"},
+		{name: "bot login", input: "renovate[bot]", want: "`@renovate[bot]`"},
+		{name: "unassigned", input: "unassigned", want: "unassigned"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatOwnerMarkdown(tt.input)
+			if got != tt.want {
+				t.Fatalf("formatOwnerMarkdown(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- render WIP owner handles as code spans instead of live `@mentions`
- preserve readability while preventing GitHub mention emails from showcase discussions
- add a small regression test for owner formatting

## Why
The daily Velocity Showcase discussion includes WIP owner tables. Rendering owners as raw `@login` values causes GitHub to send mention notifications (and huge report emails) to matching users, even though the report is automated.

This patch keeps the owner visible as `@login` but stops it from becoming a live mention.