### PR TITLE
fix: escape @mentions to stop notification spam

### DIFF
--- a/.github/workflows/velocity-item.yaml
+++ b/.github/workflows/velocity-item.yaml
@@ -1,11 +1,13 @@
 name: Item Metrics
 
 on:
-  issues:
-    types: [closed]
-  pull_request:
-    types: [closed]
-  workflow_dispatch: # Manual testing from the Actions tab
+  # DISABLED: was spamming external users with @mentions in posted comments.
+  # See: https://github.com/dvhthomas/gh-velocity/discussions/168
+  # issues:
+  #   types: [closed]
+  # pull_request:
+  #   types: [closed]
+  workflow_dispatch: # Manual-only until @mention escaping is verified
 
 permissions:
   contents: read

--- a/.github/workflows/velocity.yaml
+++ b/.github/workflows/velocity.yaml
@@ -1,10 +1,12 @@
 name: Velocity Report
 
 on:
-  schedule:
-    # Weekly on Monday at 08:00 UTC
-    - cron: "0 8 * * 1"
-  workflow_dispatch: # Allow manual runs
+  # DISABLED: was spamming external users with @mentions in posted reports.
+  # See: https://github.com/dvhthomas/gh-velocity/discussions/168
+  # schedule:
+  #   # Weekly on Monday at 08:00 UTC
+  #   - cron: "0 8 * * 1"
+  workflow_dispatch: # Manual-only until @mention escaping is verified
 
 permissions:
   contents: read

--- a/internal/format/myweek.go
+++ b/internal/format/myweek.go
@@ -402,7 +402,7 @@ func WriteMyWeekPretty(rc RenderContext, r model.MyWeekResult, ins model.MyWeekI
 			}
 			tp.AddField(FormatItemLink(pr.Number, pr.URL, rc))
 			tp.AddField(pr.Title)
-			tp.AddField("@" + author)
+			tp.AddField(author)
 			tp.AddField(formatAge(age))
 			tp.EndRow()
 		}

--- a/internal/format/myweek_test.go
+++ b/internal/format/myweek_test.go
@@ -166,7 +166,7 @@ func TestWriteMyWeekPretty(t *testing.T) {
 		// Review queue
 		"Review queue",
 		"Awaiting Your Review: 2",
-		"@alice", "@bob", "Add dark mode", "Update deps",
+		"alice", "bob", "Add dark mode", "Update deps",
 	} {
 		if !contains(out, want) {
 			t.Errorf("expected %q in output:\n%s", want, out)
@@ -263,7 +263,7 @@ func TestWriteMyWeekMarkdown(t *testing.T) {
 		// Review queue
 		"### Review queue",
 		"**Awaiting Your Review (2)**",
-		"@alice", "@bob",
+		"`@alice`", "`@bob`",
 	} {
 		if !contains(out, want) {
 			t.Errorf("expected %q in output:\n%s", want, out)

--- a/internal/format/templates/myweek.md.tmpl
+++ b/internal/format/templates/myweek.md.tmpl
@@ -98,6 +98,6 @@ _None_
 
 **Awaiting Your Review ({{len .ReviewQueue}})**
 {{range .ReviewQueue}}
-- {{.Link}} {{.Title}} — @{{.Author}} *{{.Age}}*
+- {{.Link}} {{.Title}} — `@{{.Author}}` *{{.Age}}*
 {{- end}}
 {{- end}}

--- a/internal/format/wip_detail.go
+++ b/internal/format/wip_detail.go
@@ -538,17 +538,15 @@ func WriteWIPDetailPretty(rc RenderContext, result model.WIPResult) error {
 	return nil
 }
 
-// formatOwnerMarkdown returns a GitHub @handle for markdown output.
-// GitHub's renderer auto-links @mentions, so no explicit URL needed.
+// formatOwnerMarkdown returns a GitHub handle in backtick-escaped form
+// so that GitHub's markdown renderer does NOT send @mention notifications.
 // "unassigned" is returned as-is (not a GitHub handle).
 func formatOwnerMarkdown(login string) string {
 	if login == "unassigned" {
 		return login
 	}
-	if strings.HasPrefix(login, "@") {
-		return login
-	}
-	return "@" + login
+	clean := strings.TrimPrefix(login, "@")
+	return "`@" + clean + "`"
 }
 
 // countByKind counts issues and PRs in the item list.

--- a/internal/pipeline/pr/pr_test.go
+++ b/internal/pipeline/pr/pr_test.go
@@ -274,8 +274,8 @@ func TestRenderMarkdown(t *testing.T) {
 		contains string
 	}{
 		{"Metrics header", "### Metrics"},
-		{"author in facts", "@dvhthomas"},
-		{"opened by", "Opened by @dvhthomas"},
+		{"author in facts", "`@dvhthomas`"},
+		{"opened by", "Opened by `@dvhthomas`"},
 		{"merged", "Merged 2026-03-19"},
 		{"cycle time row", "Cycle Time"},
 		{"time to first review", "Time to First Review"},

--- a/internal/pipeline/pr/render.go
+++ b/internal/pipeline/pr/render.go
@@ -13,7 +13,7 @@ import (
 // WriteMarkdown writes the PR detail as GitHub-flavored markdown.
 func WriteMarkdown(rc format.RenderContext, p *Pipeline) error {
 	// Facts — readable sentence with proper casing and punctuation.
-	facts := fmt.Sprintf("Opened by @%s%s on %s UTC",
+	facts := fmt.Sprintf("Opened by `@%s`%s on %s UTC",
 		p.PR.Author, authorTypeSuffix(p.AuthorType),
 		p.PR.CreatedAt.UTC().Format("2006-01-02 15:04"))
 	if p.PR.MergedAt != nil {
@@ -21,7 +21,7 @@ func WriteMarkdown(rc format.RenderContext, p *Pipeline) error {
 		if merger == "" || merger == p.PR.Author {
 			facts += fmt.Sprintf(". Merged %s UTC.", p.PR.MergedAt.UTC().Format("2006-01-02 15:04"))
 		} else {
-			facts += fmt.Sprintf(". Merged by @%s on %s UTC.", merger, p.PR.MergedAt.UTC().Format("2006-01-02 15:04"))
+			facts += fmt.Sprintf(". Merged by `@%s` on %s UTC.", merger, p.PR.MergedAt.UTC().Format("2006-01-02 15:04"))
 		}
 	} else {
 		facts += "."

--- a/scripts/showcase/projects.yml
+++ b/scripts/showcase/projects.yml
@@ -9,16 +9,8 @@
 # Keep this list small (≤6) to stay within API rate limits.
 
 configs:
-  - name: GitHub CLI
-    repo: cli/cli
-  - name: Kubernetes
-    repo: kubernetes/kubernetes
-  - name: uv
-    repo: astral-sh/uv
-  - name: React
-    repo: facebook/react
-  - name: k6
-    repo: grafana/k6
+  # Only repos we own — external repos were spamming maintainers with @mentions.
+  # See: https://github.com/dvhthomas/gh-velocity/discussions/168
   - name: CalcMark
     repo: CalcMark/go-calcmark
   - name: gh-velocity


### PR DESCRIPTION
## Summary

- Wraps all `@handles` in backticks across 5 output locations so GitHub's markdown renderer does **not** send notification pings
- Disables scheduled triggers on `velocity.yaml` and `velocity-item.yaml` (manual-only until verified safe)
- Strips `projects.yml` to only owned repos (`CalcMark`, `gh-velocity`)

Fixes: https://github.com/dvhthomas/gh-velocity/discussions/168

## Changed files

| File | Change |
|------|--------|
| `internal/pipeline/pr/render.go` | `@author` → `` `@author` `` in PR detail facts |
| `internal/format/wip_detail.go` | `formatOwnerMarkdown()` returns `` `@login` `` |
| `internal/format/myweek.go` | Review queue pretty-print escapes author |
| `internal/format/templates/myweek.md.tmpl` | Review queue template escapes author |
| `.github/workflows/velocity.yaml` | Disable cron schedule |
| `.github/workflows/velocity-item.yaml` | Disable issue/PR closed triggers |
| `scripts/showcase/projects.yml` | Keep only owned repos |

## Verified safe

- `scripts/smoke-test.sh` — never posts live (dry-run only), no `@mention` risk
- `scripts/showcase/` — now only hits owned repos
- Report template, WIP items table — no `@` mentions present

## Test plan

- [x] `go test ./...` — all 30 packages pass
- [x] Spot-checked `pr`, `wip`, `my-week` markdown output — all handles wrapped in backticks
- [ ] Verify on GitHub that backtick-wrapped handles don't trigger notifications

## Post-Deploy Monitoring & Validation

- **What to monitor**: GitHub notification activity for mentioned users in showcase discussions
- **Validation check**: Run `gh velocity pr 166 -R dvhthomas/gh-velocity -r markdown` and verify no bare `@handles`
- **Expected healthy behavior**: Zero notification complaints; all `@handles` render as inline code
- **Failure signal**: Any new notification spam reports on discussion #168
- **Validation window**: Next scheduled showcase run (manual trigger)
- **Owner**: dvhthomas